### PR TITLE
Feature/tint

### DIFF
--- a/brands/BOM/tokens/index.js
+++ b/brands/BOM/tokens/index.js
@@ -1,4 +1,4 @@
-import Color from 'color';
+import { tint } from './utils';
 
 const COLORS = {
 	background: '#F1F1F2',
@@ -99,16 +99,12 @@ export default {
 					},
 					hover: {
 						color: null,
-						backgroundColor: Color('white')
-							.mix(Color(COLORS.primary), 0.7)
-							.hex(),
+						backgroundColor: tint(COLORS.primary, 0.7),
 						borderColor: null,
 					},
 					active: {
 						color: '#fff',
-						backgroundColor: Color('white')
-							.mix(Color(COLORS.primary), 0.5)
-							.hex(),
+						backgroundColor: tint(COLORS.primary, 0.5),
 						borderColor: null,
 					},
 				},
@@ -120,16 +116,12 @@ export default {
 					},
 					hover: {
 						color: '#fff',
-						backgroundColor: Color('white')
-							.mix(Color(COLORS.primary), 0.7)
-							.hex(),
+						backgroundColor: tint(COLORS.primary, 0.7),
 						borderColor: null,
 					},
 					active: {
 						color: '#fff',
-						backgroundColor: Color('white')
-							.mix(Color(COLORS.primary), 0.5)
-							.hex(),
+						backgroundColor: tint(COLORS.primary, 0.5),
 						borderColor: null,
 					},
 				},
@@ -143,16 +135,12 @@ export default {
 					},
 					hover: {
 						color: null,
-						backgroundColor: Color('white')
-							.mix(Color(COLORS.hero), 0.7)
-							.hex(),
+						backgroundColor: tint(COLORS.hero, 0.7),
 						borderColor: null,
 					},
 					active: {
 						color: '#fff',
-						backgroundColor: Color('white')
-							.mix(Color(COLORS.hero), 0.5)
-							.hex(),
+						backgroundColor: tint(COLORS.hero, 0.5),
 						borderColor: null,
 					},
 				},
@@ -164,16 +152,12 @@ export default {
 					},
 					hover: {
 						color: '#fff',
-						backgroundColor: Color('white')
-							.mix(Color(COLORS.hero), 0.7)
-							.hex(),
+						backgroundColor: tint(COLORS.hero, 0.7),
 						borderColor: null,
 					},
 					active: {
 						color: '#fff',
-						backgroundColor: Color('white')
-							.mix(Color(COLORS.hero), 0.5)
-							.hex(),
+						backgroundColor: tint(COLORS.hero, 0.5),
 						borderColor: null,
 					},
 				},
@@ -187,16 +171,12 @@ export default {
 					},
 					hover: {
 						color: null,
-						backgroundColor: Color('white')
-							.mix(Color(COLORS.neutral), 0.7)
-							.hex(),
+						backgroundColor: tint(COLORS.neutral, 0.7),
 						borderColor: null,
 					},
 					active: {
 						color: '#fff',
-						backgroundColor: Color('white')
-							.mix(Color(COLORS.neutral), 0.5)
-							.hex(),
+						backgroundColor: tint(COLORS.neutral, 0.5),
 						borderColor: null,
 					},
 				},
@@ -208,16 +188,12 @@ export default {
 					},
 					hover: {
 						color: '#fff',
-						backgroundColor: Color('white')
-							.mix(Color(COLORS.neutral), 0.7)
-							.hex(),
+						backgroundColor: tint(COLORS.neutral, 0.7),
 						borderColor: null,
 					},
 					active: {
 						color: '#fff',
-						backgroundColor: Color('white')
-							.mix(Color(COLORS.neutral), 0.5)
-							.hex(),
+						backgroundColor: tint(COLORS.neutral, 0.5),
 						borderColor: null,
 					},
 				},
@@ -321,12 +297,8 @@ export default {
 				},
 				hover: {
 					color: null,
-					backgroundColor: Color('white')
-						.mix(Color(COLORS.primary), 0.5)
-						.hex(),
-					borderColor: Color('white')
-						.mix(Color(COLORS.primary), 0.5)
-						.hex(),
+					backgroundColor: tint(COLORS.primary, 0.5),
+					borderColor: tint(COLORS.primary, 0.5),
 				},
 			},
 			hero: {
@@ -337,12 +309,8 @@ export default {
 				},
 				hover: {
 					color: null,
-					backgroundColor: Color('white')
-						.mix(Color(COLORS.hero), 0.5)
-						.hex(),
-					borderColor: Color('white')
-						.mix(Color(COLORS.hero), 0.5)
-						.hex(),
+					backgroundColor: tint(COLORS.hero, 0.5),
+					borderColor: tint(COLORS.hero, 0.5),
 				},
 			},
 			neutral: {
@@ -353,12 +321,8 @@ export default {
 				},
 				hover: {
 					color: null,
-					backgroundColor: Color('white')
-						.mix(Color(COLORS.neutral), 0.5)
-						.hex(),
-					borderColor: Color('white')
-						.mix(Color(COLORS.neutral), 0.5)
-						.hex(),
+					backgroundColor: tint(COLORS.neutral, 0.5),
+					borderColor: tint(COLORS.neutral, 0.5),
 				},
 			},
 			faint: {
@@ -381,12 +345,8 @@ export default {
 				},
 				hover: {
 					color: null,
-					backgroundColor: Color('white')
-						.mix(Color(COLORS.success), 0.5)
-						.hex(),
-					borderColor: Color('white')
-						.mix(Color(COLORS.success), 0.5)
-						.hex(),
+					backgroundColor: tint(COLORS.success, 0.5),
+					borderColor: tint(COLORS.success, 0.5),
 				},
 			},
 			information: {
@@ -397,12 +357,8 @@ export default {
 				},
 				hover: {
 					color: null,
-					backgroundColor: Color('white')
-						.mix(Color(COLORS.information), 0.5)
-						.hex(),
-					borderColor: Color('white')
-						.mix(Color(COLORS.information), 0.5)
-						.hex(),
+					backgroundColor: tint(COLORS.information, 0.5),
+					borderColor: tint(COLORS.information, 0.5),
 				},
 			},
 			warning: {
@@ -413,12 +369,8 @@ export default {
 				},
 				hover: {
 					color: null,
-					backgroundColor: Color('white')
-						.mix(Color(COLORS.warning), 0.5)
-						.hex(),
-					borderColor: Color('white')
-						.mix(Color(COLORS.warning), 0.5)
-						.hex(),
+					backgroundColor: tint(COLORS.warning, 0.5),
+					borderColor: tint(COLORS.warning, 0.5),
 				},
 			},
 			danger: {
@@ -429,12 +381,8 @@ export default {
 				},
 				hover: {
 					color: null,
-					backgroundColor: Color('white')
-						.mix(Color(COLORS.danger), 0.5)
-						.hex(),
-					borderColor: Color('white')
-						.mix(Color(COLORS.danger), 0.5)
-						.hex(),
+					backgroundColor: tint(COLORS.danger, 0.5),
+					borderColor: tint(COLORS.danger, 0.5),
 				},
 			},
 		},

--- a/brands/BOM/tokens/utils.js
+++ b/brands/BOM/tokens/utils.js
@@ -1,0 +1,6 @@
+import Color from 'color';
+
+export const tint = (color, amount) =>
+	Color('white')
+		.mix(Color(color), amount)
+		.hex();

--- a/brands/BSA/tokens/index.js
+++ b/brands/BSA/tokens/index.js
@@ -1,4 +1,4 @@
-import Color from 'color';
+import { tint } from './utils';
 
 const COLORS = {
 	background: '#F0F1F1',
@@ -99,16 +99,12 @@ export default {
 					},
 					hover: {
 						color: null,
-						backgroundColor: Color('white')
-							.mix(Color(COLORS.primary), 0.7)
-							.hex(),
+						backgroundColor: tint(COLORS.primary, 0.7),
 						borderColor: null,
 					},
 					active: {
 						color: '#fff',
-						backgroundColor: Color('white')
-							.mix(Color(COLORS.primary), 0.5)
-							.hex(),
+						backgroundColor: tint(COLORS.primary, 0.5),
 						borderColor: null,
 					},
 				},
@@ -120,16 +116,12 @@ export default {
 					},
 					hover: {
 						color: '#fff',
-						backgroundColor: Color('white')
-							.mix(Color(COLORS.primary), 0.7)
-							.hex(),
+						backgroundColor: tint(COLORS.primary, 0.7),
 						borderColor: null,
 					},
 					active: {
 						color: '#fff',
-						backgroundColor: Color('white')
-							.mix(Color(COLORS.primary), 0.5)
-							.hex(),
+						backgroundColor: tint(COLORS.primary, 0.5),
 						borderColor: null,
 					},
 				},
@@ -143,16 +135,12 @@ export default {
 					},
 					hover: {
 						color: null,
-						backgroundColor: Color('white')
-							.mix(Color(COLORS.hero), 0.7)
-							.hex(),
+						backgroundColor: tint(COLORS.hero, 0.7),
 						borderColor: null,
 					},
 					active: {
 						color: '#fff',
-						backgroundColor: Color('white')
-							.mix(Color(COLORS.hero), 0.5)
-							.hex(),
+						backgroundColor: tint(COLORS.hero, 0.5),
 						borderColor: null,
 					},
 				},
@@ -164,16 +152,12 @@ export default {
 					},
 					hover: {
 						color: '#fff',
-						backgroundColor: Color('white')
-							.mix(Color(COLORS.hero), 0.7)
-							.hex(),
+						backgroundColor: tint(COLORS.hero, 0.7),
 						borderColor: null,
 					},
 					active: {
 						color: '#fff',
-						backgroundColor: Color('white')
-							.mix(Color(COLORS.hero), 0.5)
-							.hex(),
+						backgroundColor: tint(COLORS.hero, 0.5),
 						borderColor: null,
 					},
 				},
@@ -187,16 +171,12 @@ export default {
 					},
 					hover: {
 						color: null,
-						backgroundColor: Color('white')
-							.mix(Color(COLORS.neutral), 0.7)
-							.hex(),
+						backgroundColor: tint(COLORS.neutral, 0.7),
 						borderColor: null,
 					},
 					active: {
 						color: '#fff',
-						backgroundColor: Color('white')
-							.mix(Color(COLORS.neutral), 0.5)
-							.hex(),
+						backgroundColor: tint(COLORS.neutral, 0.5),
 						borderColor: null,
 					},
 				},
@@ -208,16 +188,12 @@ export default {
 					},
 					hover: {
 						color: '#fff',
-						backgroundColor: Color('white')
-							.mix(Color(COLORS.neutral), 0.7)
-							.hex(),
+						backgroundColor: tint(COLORS.neutral, 0.7),
 						borderColor: null,
 					},
 					active: {
 						color: '#fff',
-						backgroundColor: Color('white')
-							.mix(Color(COLORS.neutral), 0.5)
-							.hex(),
+						backgroundColor: tint(COLORS.neutral, 0.5),
 						borderColor: null,
 					},
 				},
@@ -321,12 +297,8 @@ export default {
 				},
 				hover: {
 					color: null,
-					backgroundColor: Color('white')
-						.mix(Color(COLORS.primary), 0.5)
-						.hex(),
-					borderColor: Color('white')
-						.mix(Color(COLORS.primary), 0.5)
-						.hex(),
+					backgroundColor: tint(COLORS.primary, 0.5),
+					borderColor: tint(COLORS.primary, 0.5),
 				},
 			},
 			hero: {
@@ -337,12 +309,8 @@ export default {
 				},
 				hover: {
 					color: null,
-					backgroundColor: Color('white')
-						.mix(Color(COLORS.hero), 0.5)
-						.hex(),
-					borderColor: Color('white')
-						.mix(Color(COLORS.hero), 0.5)
-						.hex(),
+					backgroundColor: tint(COLORS.hero, 0.5),
+					borderColor: tint(COLORS.hero, 0.5),
 				},
 			},
 			neutral: {
@@ -353,12 +321,8 @@ export default {
 				},
 				hover: {
 					color: null,
-					backgroundColor: Color('white')
-						.mix(Color(COLORS.neutral), 0.5)
-						.hex(),
-					borderColor: Color('white')
-						.mix(Color(COLORS.neutral), 0.5)
-						.hex(),
+					backgroundColor: tint(COLORS.neutral, 0.5),
+					borderColor: tint(COLORS.neutral, 0.5),
 				},
 			},
 			faint: {
@@ -381,12 +345,8 @@ export default {
 				},
 				hover: {
 					color: null,
-					backgroundColor: Color('white')
-						.mix(Color(COLORS.success), 0.5)
-						.hex(),
-					borderColor: Color('white')
-						.mix(Color(COLORS.success), 0.5)
-						.hex(),
+					backgroundColor: tint(COLORS.success, 0.5),
+					borderColor: tint(COLORS.success, 0.5),
 				},
 			},
 			information: {
@@ -397,12 +357,8 @@ export default {
 				},
 				hover: {
 					color: null,
-					backgroundColor: Color('white')
-						.mix(Color(COLORS.information), 0.5)
-						.hex(),
-					borderColor: Color('white')
-						.mix(Color(COLORS.information), 0.5)
-						.hex(),
+					backgroundColor: tint(COLORS.information, 0.5),
+					borderColor: tint(COLORS.information, 0.5),
 				},
 			},
 			warning: {
@@ -413,12 +369,8 @@ export default {
 				},
 				hover: {
 					color: null,
-					backgroundColor: Color('white')
-						.mix(Color(COLORS.warning), 0.5)
-						.hex(),
-					borderColor: Color('white')
-						.mix(Color(COLORS.warning), 0.5)
-						.hex(),
+					backgroundColor: tint(COLORS.warning, 0.5),
+					borderColor: tint(COLORS.warning, 0.5),
 				},
 			},
 			danger: {
@@ -429,12 +381,8 @@ export default {
 				},
 				hover: {
 					color: null,
-					backgroundColor: Color('white')
-						.mix(Color(COLORS.danger), 0.5)
-						.hex(),
-					borderColor: Color('white')
-						.mix(Color(COLORS.danger), 0.5)
-						.hex(),
+					backgroundColor: tint(COLORS.danger, 0.5),
+					borderColor: tint(COLORS.danger, 0.5),
 				},
 			},
 		},

--- a/brands/BSA/tokens/utils.js
+++ b/brands/BSA/tokens/utils.js
@@ -1,0 +1,6 @@
+import Color from 'color';
+
+export const tint = (color, amount) =>
+	Color('white')
+		.mix(Color(color), amount)
+		.hex();

--- a/brands/BTFG/tokens/index.js
+++ b/brands/BTFG/tokens/index.js
@@ -1,4 +1,4 @@
-import Color from 'color';
+import { tint } from './utils';
 
 const COLORS = {
 	background: '#F9F9F9',
@@ -99,16 +99,12 @@ export default {
 					},
 					hover: {
 						color: null,
-						backgroundColor: Color('white')
-							.mix(Color(COLORS.primary), 0.7)
-							.hex(),
+						backgroundColor: tint(COLORS.primary, 0.7),
 						borderColor: null,
 					},
 					active: {
 						color: '#fff',
-						backgroundColor: Color('white')
-							.mix(Color(COLORS.primary), 0.5)
-							.hex(),
+						backgroundColor: tint(COLORS.primary, 0.5),
 						borderColor: null,
 					},
 				},
@@ -120,16 +116,12 @@ export default {
 					},
 					hover: {
 						color: '#fff',
-						backgroundColor: Color('white')
-							.mix(Color(COLORS.primary), 0.7)
-							.hex(),
+						backgroundColor: tint(COLORS.primary, 0.7),
 						borderColor: null,
 					},
 					active: {
 						color: '#fff',
-						backgroundColor: Color('white')
-							.mix(Color(COLORS.primary), 0.5)
-							.hex(),
+						backgroundColor: tint(COLORS.primary, 0.5),
 						borderColor: null,
 					},
 				},
@@ -143,16 +135,12 @@ export default {
 					},
 					hover: {
 						color: null,
-						backgroundColor: Color('white')
-							.mix(Color(COLORS.hero), 0.7)
-							.hex(),
+						backgroundColor: tint(COLORS.hero, 0.7),
 						borderColor: null,
 					},
 					active: {
 						color: '#fff',
-						backgroundColor: Color('white')
-							.mix(Color(COLORS.hero), 0.5)
-							.hex(),
+						backgroundColor: tint(COLORS.hero, 0.5),
 						borderColor: null,
 					},
 				},
@@ -164,16 +152,12 @@ export default {
 					},
 					hover: {
 						color: '#fff',
-						backgroundColor: Color('white')
-							.mix(Color(COLORS.hero), 0.7)
-							.hex(),
+						backgroundColor: tint(COLORS.hero, 0.7),
 						borderColor: null,
 					},
 					active: {
 						color: '#fff',
-						backgroundColor: Color('white')
-							.mix(Color(COLORS.hero), 0.5)
-							.hex(),
+						backgroundColor: tint(COLORS.hero, 0.5),
 						borderColor: null,
 					},
 				},
@@ -187,16 +171,12 @@ export default {
 					},
 					hover: {
 						color: null,
-						backgroundColor: Color('white')
-							.mix(Color(COLORS.neutral), 0.7)
-							.hex(),
+						backgroundColor: tint(COLORS.neutral, 0.7),
 						borderColor: null,
 					},
 					active: {
 						color: '#fff',
-						backgroundColor: Color('white')
-							.mix(Color(COLORS.neutral), 0.5)
-							.hex(),
+						backgroundColor: tint(COLORS.neutral, 0.5),
 						borderColor: null,
 					},
 				},
@@ -208,16 +188,12 @@ export default {
 					},
 					hover: {
 						color: '#fff',
-						backgroundColor: Color('white')
-							.mix(Color(COLORS.neutral), 0.7)
-							.hex(),
+						backgroundColor: tint(COLORS.neutral, 0.7),
 						borderColor: null,
 					},
 					active: {
 						color: '#fff',
-						backgroundColor: Color('white')
-							.mix(Color(COLORS.neutral), 0.5)
-							.hex(),
+						backgroundColor: tint(COLORS.neutral, 0.5),
 						borderColor: null,
 					},
 				},
@@ -321,12 +297,8 @@ export default {
 				},
 				hover: {
 					color: null,
-					backgroundColor: Color('white')
-						.mix(Color(COLORS.primary), 0.5)
-						.hex(),
-					borderColor: Color('white')
-						.mix(Color(COLORS.primary), 0.5)
-						.hex(),
+					backgroundColor: tint(COLORS.primary, 0.5),
+					borderColor: tint(COLORS.primary, 0.5),
 				},
 			},
 			hero: {
@@ -337,12 +309,8 @@ export default {
 				},
 				hover: {
 					color: null,
-					backgroundColor: Color('white')
-						.mix(Color(COLORS.hero), 0.5)
-						.hex(),
-					borderColor: Color('white')
-						.mix(Color(COLORS.hero), 0.5)
-						.hex(),
+					backgroundColor: tint(COLORS.hero, 0.5),
+					borderColor: tint(COLORS.hero, 0.5),
 				},
 			},
 			neutral: {
@@ -353,12 +321,8 @@ export default {
 				},
 				hover: {
 					color: null,
-					backgroundColor: Color('white')
-						.mix(Color(COLORS.neutral), 0.5)
-						.hex(),
-					borderColor: Color('white')
-						.mix(Color(COLORS.neutral), 0.5)
-						.hex(),
+					backgroundColor: tint(COLORS.neutral, 0.5),
+					borderColor: tint(COLORS.neutral, 0.5),
 				},
 			},
 			faint: {
@@ -381,12 +345,8 @@ export default {
 				},
 				hover: {
 					color: null,
-					backgroundColor: Color('white')
-						.mix(Color(COLORS.success), 0.5)
-						.hex(),
-					borderColor: Color('white')
-						.mix(Color(COLORS.success), 0.5)
-						.hex(),
+					backgroundColor: tint(COLORS.success, 0.5),
+					borderColor: tint(COLORS.success, 0.5),
 				},
 			},
 			information: {
@@ -397,12 +357,8 @@ export default {
 				},
 				hover: {
 					color: null,
-					backgroundColor: Color('white')
-						.mix(Color(COLORS.information), 0.5)
-						.hex(),
-					borderColor: Color('white')
-						.mix(Color(COLORS.information), 0.5)
-						.hex(),
+					backgroundColor: tint(COLORS.information, 0.5),
+					borderColor: tint(COLORS.information, 0.5),
 				},
 			},
 			warning: {
@@ -413,12 +369,8 @@ export default {
 				},
 				hover: {
 					color: null,
-					backgroundColor: Color('white')
-						.mix(Color(COLORS.warning), 0.5)
-						.hex(),
-					borderColor: Color('white')
-						.mix(Color(COLORS.warning), 0.5)
-						.hex(),
+					backgroundColor: tint(COLORS.warning, 0.5),
+					borderColor: tint(COLORS.warning, 0.5),
 				},
 			},
 			danger: {
@@ -429,12 +381,8 @@ export default {
 				},
 				hover: {
 					color: null,
-					backgroundColor: Color('white')
-						.mix(Color(COLORS.danger), 0.5)
-						.hex(),
-					borderColor: Color('white')
-						.mix(Color(COLORS.danger), 0.5)
-						.hex(),
+					backgroundColor: tint(COLORS.danger, 0.5),
+					borderColor: tint(COLORS.danger, 0.5),
 				},
 			},
 		},

--- a/brands/BTFG/tokens/utils.js
+++ b/brands/BTFG/tokens/utils.js
@@ -1,0 +1,6 @@
+import Color from 'color';
+
+export const tint = (color, amount) =>
+	Color('white')
+		.mix(Color(color), amount)
+		.hex();

--- a/brands/STG/tokens/index.js
+++ b/brands/STG/tokens/index.js
@@ -72,114 +72,6 @@ export default {
 		},
 	},
 
-	label: {
-		borderRadius: '2px',
-		borderWidth: '1px',
-		fontSize: '12px',
-		padding: '1px 6px',
-		fontWeight: 400,
-		lineHeight: 1,
-
-		appearance: {
-			primary: {
-				default: {
-					color: '#fff',
-					backgroundColor: COLORS.primary,
-					borderColor: COLORS.primary,
-				},
-				hover: {
-					color: null,
-					backgroundColor: tint(COLORS.primary, 0.5),
-					borderColor: tint(COLORS.primary, 0.5),
-				},
-			},
-			hero: {
-				default: {
-					color: COLORS.text,
-					backgroundColor: COLORS.hero,
-					borderColor: COLORS.hero,
-				},
-				hover: {
-					color: null,
-					backgroundColor: tint(COLORS.hero, 0.5),
-					borderColor: tint(COLORS.hero, 0.5),
-				},
-			},
-			neutral: {
-				default: {
-					color: '#fff',
-					backgroundColor: COLORS.neutral,
-					borderColor: COLORS.neutral,
-				},
-				hover: {
-					color: null,
-					backgroundColor: tint(COLORS.neutral, 0.5),
-					borderColor: tint(COLORS.neutral, 0.5),
-				},
-			},
-			faint: {
-				default: {
-					color: COLORS.muted,
-					backgroundColor: COLORS.light,
-					borderColor: COLORS.border,
-				},
-				hover: {
-					color: null,
-					backgroundColor: '#fff',
-					borderColor: null,
-				},
-			},
-			success: {
-				default: {
-					color: '#fff',
-					backgroundColor: COLORS.success,
-					borderColor: COLORS.success,
-				},
-				hover: {
-					color: null,
-					backgroundColor: tint(COLORS.success, 0.5),
-					borderColor: tint(COLORS.success, 0.5),
-				},
-			},
-			information: {
-				default: {
-					color: '#fff',
-					backgroundColor: COLORS.information,
-					borderColor: COLORS.information,
-				},
-				hover: {
-					color: null,
-					backgroundColor: tint(COLORS.information, 0.5),
-					borderColor: tint(COLORS.information, 0.5),
-				},
-			},
-			warning: {
-				default: {
-					color: '#fff',
-					backgroundColor: COLORS.warning,
-					borderColor: COLORS.warning,
-				},
-				hover: {
-					color: null,
-					backgroundColor: tint(COLORS.warning, 0.5),
-					borderColor: tint(COLORS.warning, 0.5),
-				},
-			},
-			danger: {
-				default: {
-					color: '#fff',
-					backgroundColor: COLORS.danger,
-					borderColor: COLORS.danger,
-				},
-				hover: {
-					color: null,
-					backgroundColor: tint(COLORS.danger, 0.5),
-					borderColor: tint(COLORS.danger, 0.5),
-				},
-			},
-		},
-	},
-
 	badge: {
 		minWidth: '10px',
 		minWidth: '10px',
@@ -384,6 +276,114 @@ export default {
 				padding: ['9px', '18px', '10px'],
 				fontSize: '18px',
 				height: '48px',
+			},
+		},
+	},
+
+	label: {
+		borderRadius: '2px',
+		borderWidth: '1px',
+		fontSize: '12px',
+		padding: '1px 6px',
+		fontWeight: 400,
+		lineHeight: 1,
+
+		appearance: {
+			primary: {
+				default: {
+					color: '#fff',
+					backgroundColor: COLORS.primary,
+					borderColor: COLORS.primary,
+				},
+				hover: {
+					color: null,
+					backgroundColor: tint(COLORS.primary, 0.5),
+					borderColor: tint(COLORS.primary, 0.5),
+				},
+			},
+			hero: {
+				default: {
+					color: COLORS.text,
+					backgroundColor: COLORS.hero,
+					borderColor: COLORS.hero,
+				},
+				hover: {
+					color: null,
+					backgroundColor: tint(COLORS.hero, 0.5),
+					borderColor: tint(COLORS.hero, 0.5),
+				},
+			},
+			neutral: {
+				default: {
+					color: '#fff',
+					backgroundColor: COLORS.neutral,
+					borderColor: COLORS.neutral,
+				},
+				hover: {
+					color: null,
+					backgroundColor: tint(COLORS.neutral, 0.5),
+					borderColor: tint(COLORS.neutral, 0.5),
+				},
+			},
+			faint: {
+				default: {
+					color: COLORS.muted,
+					backgroundColor: COLORS.light,
+					borderColor: COLORS.border,
+				},
+				hover: {
+					color: null,
+					backgroundColor: '#fff',
+					borderColor: null,
+				},
+			},
+			success: {
+				default: {
+					color: '#fff',
+					backgroundColor: COLORS.success,
+					borderColor: COLORS.success,
+				},
+				hover: {
+					color: null,
+					backgroundColor: tint(COLORS.success, 0.5),
+					borderColor: tint(COLORS.success, 0.5),
+				},
+			},
+			information: {
+				default: {
+					color: '#fff',
+					backgroundColor: COLORS.information,
+					borderColor: COLORS.information,
+				},
+				hover: {
+					color: null,
+					backgroundColor: tint(COLORS.information, 0.5),
+					borderColor: tint(COLORS.information, 0.5),
+				},
+			},
+			warning: {
+				default: {
+					color: '#fff',
+					backgroundColor: COLORS.warning,
+					borderColor: COLORS.warning,
+				},
+				hover: {
+					color: null,
+					backgroundColor: tint(COLORS.warning, 0.5),
+					borderColor: tint(COLORS.warning, 0.5),
+				},
+			},
+			danger: {
+				default: {
+					color: '#fff',
+					backgroundColor: COLORS.danger,
+					borderColor: COLORS.danger,
+				},
+				hover: {
+					color: null,
+					backgroundColor: tint(COLORS.danger, 0.5),
+					borderColor: tint(COLORS.danger, 0.5),
+				},
 			},
 		},
 	},

--- a/brands/STG/tokens/index.js
+++ b/brands/STG/tokens/index.js
@@ -1,4 +1,4 @@
-import Color from 'color';
+import { tint } from './utils';
 
 const COLORS = {
 	background: '#F1F1EF',
@@ -89,12 +89,8 @@ export default {
 				},
 				hover: {
 					color: null,
-					backgroundColor: Color('white')
-						.mix(Color(COLORS.primary), 0.5)
-						.hex(),
-					borderColor: Color('white')
-						.mix(Color(COLORS.primary), 0.5)
-						.hex(),
+					backgroundColor: tint(COLORS.primary, 0.5),
+					borderColor: tint(COLORS.primary, 0.5),
 				},
 			},
 			hero: {
@@ -105,12 +101,8 @@ export default {
 				},
 				hover: {
 					color: null,
-					backgroundColor: Color('white')
-						.mix(Color(COLORS.hero), 0.5)
-						.hex(),
-					borderColor: Color('white')
-						.mix(Color(COLORS.hero), 0.5)
-						.hex(),
+					backgroundColor: tint(COLORS.hero, 0.5),
+					borderColor: tint(COLORS.hero, 0.5),
 				},
 			},
 			neutral: {
@@ -121,12 +113,8 @@ export default {
 				},
 				hover: {
 					color: null,
-					backgroundColor: Color('white')
-						.mix(Color(COLORS.neutral), 0.5)
-						.hex(),
-					borderColor: Color('white')
-						.mix(Color(COLORS.neutral), 0.5)
-						.hex(),
+					backgroundColor: tint(COLORS.neutral, 0.5),
+					borderColor: tint(COLORS.neutral, 0.5),
 				},
 			},
 			faint: {
@@ -149,12 +137,8 @@ export default {
 				},
 				hover: {
 					color: null,
-					backgroundColor: Color('white')
-						.mix(Color(COLORS.success), 0.5)
-						.hex(),
-					borderColor: Color('white')
-						.mix(Color(COLORS.success), 0.5)
-						.hex(),
+					backgroundColor: tint(COLORS.success, 0.5),
+					borderColor: tint(COLORS.success, 0.5),
 				},
 			},
 			information: {
@@ -165,12 +149,8 @@ export default {
 				},
 				hover: {
 					color: null,
-					backgroundColor: Color('white')
-						.mix(Color(COLORS.information), 0.5)
-						.hex(),
-					borderColor: Color('white')
-						.mix(Color(COLORS.information), 0.5)
-						.hex(),
+					backgroundColor: tint(COLORS.information, 0.5),
+					borderColor: tint(COLORS.information, 0.5),
 				},
 			},
 			warning: {
@@ -181,12 +161,8 @@ export default {
 				},
 				hover: {
 					color: null,
-					backgroundColor: Color('white')
-						.mix(Color(COLORS.warning), 0.5)
-						.hex(),
-					borderColor: Color('white')
-						.mix(Color(COLORS.warning), 0.5)
-						.hex(),
+					backgroundColor: tint(COLORS.warning, 0.5),
+					borderColor: tint(COLORS.warning, 0.5),
 				},
 			},
 			danger: {
@@ -197,12 +173,8 @@ export default {
 				},
 				hover: {
 					color: null,
-					backgroundColor: Color('white')
-						.mix(Color(COLORS.danger), 0.5)
-						.hex(),
-					borderColor: Color('white')
-						.mix(Color(COLORS.danger), 0.5)
-						.hex(),
+					backgroundColor: tint(COLORS.danger, 0.5),
+					borderColor: tint(COLORS.danger, 0.5),
 				},
 			},
 		},
@@ -235,16 +207,12 @@ export default {
 					},
 					hover: {
 						color: null,
-						backgroundColor: Color('white')
-							.mix(Color(COLORS.primary), 0.7)
-							.hex(),
+						backgroundColor: tint(COLORS.primary, 0.7),
 						borderColor: null,
 					},
 					active: {
 						color: '#fff',
-						backgroundColor: Color('white')
-							.mix(Color(COLORS.primary), 0.5)
-							.hex(),
+						backgroundColor: tint(COLORS.primary, 0.5),
 						borderColor: null,
 					},
 				},
@@ -256,16 +224,12 @@ export default {
 					},
 					hover: {
 						color: '#fff',
-						backgroundColor: Color('white')
-							.mix(Color(COLORS.primary), 0.7)
-							.hex(),
+						backgroundColor: tint(COLORS.primary, 0.7),
 						borderColor: null,
 					},
 					active: {
 						color: '#fff',
-						backgroundColor: Color('white')
-							.mix(Color(COLORS.primary), 0.5)
-							.hex(),
+						backgroundColor: tint(COLORS.primary, 0.5),
 						borderColor: null,
 					},
 				},
@@ -279,16 +243,12 @@ export default {
 					},
 					hover: {
 						color: COLORS.text, //mapping unique to this brand
-						backgroundColor: Color('white')
-							.mix(Color(COLORS.hero), 0.7)
-							.hex(),
+						backgroundColor: tint(COLORS.hero, 0.7),
 						borderColor: null,
 					},
 					active: {
 						color: COLORS.text, //mapping unique to this brand
-						backgroundColor: Color('white')
-							.mix(Color(COLORS.hero), 0.5)
-							.hex(),
+						backgroundColor: tint(COLORS.hero, 0.5),
 						borderColor: null,
 					},
 				},
@@ -300,16 +260,12 @@ export default {
 					},
 					hover: {
 						color: null, //mapping unique to this brand
-						backgroundColor: Color('white')
-							.mix(Color(COLORS.hero), 0.7)
-							.hex(),
+						backgroundColor: tint(COLORS.hero, 0.7),
 						borderColor: null,
 					},
 					active: {
 						color: null, //mapping unique to this brand
-						backgroundColor: Color('white')
-							.mix(Color(COLORS.hero), 0.5)
-							.hex(),
+						backgroundColor: tint(COLORS.hero, 0.5),
 						borderColor: null,
 					},
 				},
@@ -323,16 +279,12 @@ export default {
 					},
 					hover: {
 						color: null,
-						backgroundColor: Color('white')
-							.mix(Color(COLORS.neutral), 0.7)
-							.hex(),
+						backgroundColor: tint(COLORS.neutral, 0.7),
 						borderColor: null,
 					},
 					active: {
 						color: '#fff',
-						backgroundColor: Color('white')
-							.mix(Color(COLORS.neutral), 0.5)
-							.hex(),
+						backgroundColor: tint(COLORS.neutral, 0.5),
 						borderColor: null,
 					},
 				},
@@ -344,16 +296,12 @@ export default {
 					},
 					hover: {
 						color: '#fff',
-						backgroundColor: Color('white')
-							.mix(Color(COLORS.neutral), 0.7)
-							.hex(),
+						backgroundColor: tint(COLORS.neutral, 0.7),
 						borderColor: null,
 					},
 					active: {
 						color: '#fff',
-						backgroundColor: Color('white')
-							.mix(Color(COLORS.neutral), 0.5)
-							.hex(),
+						backgroundColor: tint(COLORS.neutral, 0.5),
 						borderColor: null,
 					},
 				},

--- a/brands/STG/tokens/utils.js
+++ b/brands/STG/tokens/utils.js
@@ -1,0 +1,6 @@
+import Color from 'color';
+
+export const tint = (color, amount) =>
+	Color('white')
+		.mix(Color(color), amount)
+		.hex();

--- a/brands/WBC/tokens/index.js
+++ b/brands/WBC/tokens/index.js
@@ -1,4 +1,4 @@
-import Color from 'color';
+import { tint } from './utils';
 
 const COLORS = {
 	background: '#F4F3F0',
@@ -99,16 +99,12 @@ export default {
 					},
 					hover: {
 						color: null,
-						backgroundColor: Color('white')
-							.mix(Color(COLORS.primary), 0.7)
-							.hex(),
+						backgroundColor: tint(COLORS.primary, 0.7),
 						borderColor: null,
 					},
 					active: {
 						color: '#fff',
-						backgroundColor: Color('white')
-							.mix(Color(COLORS.primary), 0.5)
-							.hex(),
+						backgroundColor: tint(COLORS.primary, 0.5),
 						borderColor: null,
 					},
 				},
@@ -120,16 +116,12 @@ export default {
 					},
 					hover: {
 						color: '#fff',
-						backgroundColor: Color('white')
-							.mix(Color(COLORS.primary), 0.7)
-							.hex(),
+						backgroundColor: tint(COLORS.primary, 0.7),
 						borderColor: null,
 					},
 					active: {
 						color: '#fff',
-						backgroundColor: Color('white')
-							.mix(Color(COLORS.primary), 0.5)
-							.hex(),
+						backgroundColor: tint(COLORS.primary, 0.5),
 						borderColor: null,
 					},
 				},
@@ -143,16 +135,12 @@ export default {
 					},
 					hover: {
 						color: null,
-						backgroundColor: Color('white')
-							.mix(Color(COLORS.hero), 0.7)
-							.hex(),
+						backgroundColor: tint(COLORS.hero, 0.7),
 						borderColor: null,
 					},
 					active: {
 						color: '#fff',
-						backgroundColor: Color('white')
-							.mix(Color(COLORS.hero), 0.5)
-							.hex(),
+						backgroundColor: tint(COLORS.hero, 0.5),
 						borderColor: null,
 					},
 				},
@@ -164,16 +152,12 @@ export default {
 					},
 					hover: {
 						color: '#fff',
-						backgroundColor: Color('white')
-							.mix(Color(COLORS.hero), 0.7)
-							.hex(),
+						backgroundColor: tint(COLORS.hero, 0.7),
 						borderColor: null,
 					},
 					active: {
 						color: '#fff',
-						backgroundColor: Color('white')
-							.mix(Color(COLORS.hero), 0.5)
-							.hex(),
+						backgroundColor: tint(COLORS.hero, 0.5),
 						borderColor: null,
 					},
 				},
@@ -187,16 +171,12 @@ export default {
 					},
 					hover: {
 						color: null,
-						backgroundColor: Color('white')
-							.mix(Color(COLORS.neutral), 0.7)
-							.hex(),
+						backgroundColor: tint(COLORS.neutral, 0.7),
 						borderColor: null,
 					},
 					active: {
 						color: '#fff',
-						backgroundColor: Color('white')
-							.mix(Color(COLORS.neutral), 0.5)
-							.hex(),
+						backgroundColor: tint(COLORS.neutral, 0.5),
 						borderColor: null,
 					},
 				},
@@ -208,16 +188,12 @@ export default {
 					},
 					hover: {
 						color: '#fff',
-						backgroundColor: Color('white')
-							.mix(Color(COLORS.neutral), 0.7)
-							.hex(),
+						backgroundColor: tint(COLORS.neutral, 0.7),
 						borderColor: null,
 					},
 					active: {
 						color: '#fff',
-						backgroundColor: Color('white')
-							.mix(Color(COLORS.neutral), 0.5)
-							.hex(),
+						backgroundColor: tint(COLORS.neutral, 0.5),
 						borderColor: null,
 					},
 				},
@@ -321,12 +297,8 @@ export default {
 				},
 				hover: {
 					color: null,
-					backgroundColor: Color('white')
-						.mix(Color(COLORS.primary), 0.5)
-						.hex(),
-					borderColor: Color('white')
-						.mix(Color(COLORS.primary), 0.5)
-						.hex(),
+					backgroundColor: tint(COLORS.primary, 0.5),
+					borderColor: tint(COLORS.primary, 0.5),
 				},
 			},
 			hero: {
@@ -337,12 +309,8 @@ export default {
 				},
 				hover: {
 					color: null,
-					backgroundColor: Color('white')
-						.mix(Color(COLORS.hero), 0.5)
-						.hex(),
-					borderColor: Color('white')
-						.mix(Color(COLORS.hero), 0.5)
-						.hex(),
+					backgroundColor: tint(COLORS.hero, 0.5),
+					borderColor: tint(COLORS.hero, 0.5),
 				},
 			},
 			neutral: {
@@ -353,12 +321,8 @@ export default {
 				},
 				hover: {
 					color: null,
-					backgroundColor: Color('white')
-						.mix(Color(COLORS.neutral), 0.5)
-						.hex(),
-					borderColor: Color('white')
-						.mix(Color(COLORS.neutral), 0.5)
-						.hex(),
+					backgroundColor: tint(COLORS.neutral, 0.5),
+					borderColor: tint(COLORS.neutral, 0.5),
 				},
 			},
 			faint: {
@@ -381,12 +345,8 @@ export default {
 				},
 				hover: {
 					color: null,
-					backgroundColor: Color('white')
-						.mix(Color(COLORS.success), 0.5)
-						.hex(),
-					borderColor: Color('white')
-						.mix(Color(COLORS.success), 0.5)
-						.hex(),
+					backgroundColor: tint(COLORS.success, 0.5),
+					borderColor: tint(COLORS.success, 0.5),
 				},
 			},
 			information: {
@@ -397,12 +357,8 @@ export default {
 				},
 				hover: {
 					color: null,
-					backgroundColor: Color('white')
-						.mix(Color(COLORS.information), 0.5)
-						.hex(),
-					borderColor: Color('white')
-						.mix(Color(COLORS.information), 0.5)
-						.hex(),
+					backgroundColor: tint(COLORS.information, 0.5),
+					borderColor: tint(COLORS.information, 0.5),
 				},
 			},
 			warning: {
@@ -413,12 +369,8 @@ export default {
 				},
 				hover: {
 					color: null,
-					backgroundColor: Color('white')
-						.mix(Color(COLORS.warning), 0.5)
-						.hex(),
-					borderColor: Color('white')
-						.mix(Color(COLORS.warning), 0.5)
-						.hex(),
+					backgroundColor: tint(COLORS.warning, 0.5),
+					borderColor: tint(COLORS.warning, 0.5),
 				},
 			},
 			danger: {
@@ -429,12 +381,8 @@ export default {
 				},
 				hover: {
 					color: null,
-					backgroundColor: Color('white')
-						.mix(Color(COLORS.danger), 0.5)
-						.hex(),
-					borderColor: Color('white')
-						.mix(Color(COLORS.danger), 0.5)
-						.hex(),
+					backgroundColor: tint(COLORS.danger, 0.5),
+					borderColor: tint(COLORS.danger, 0.5),
 				},
 			},
 		},

--- a/brands/WBC/tokens/utils.js
+++ b/brands/WBC/tokens/utils.js
@@ -1,0 +1,6 @@
+import Color from 'color';
+
+export const tint = (color, amount) =>
+	Color('white')
+		.mix(Color(color), amount)
+		.hex();

--- a/brands/WBG/tokens/index.js
+++ b/brands/WBG/tokens/index.js
@@ -1,4 +1,4 @@
-import Color from 'color';
+import { tint } from './utils';
 
 const COLORS = {
 	background: '#F3F5F6',
@@ -99,16 +99,12 @@ export default {
 					},
 					hover: {
 						color: null,
-						backgroundColor: Color('white')
-							.mix(Color(COLORS.primary), 0.7)
-							.hex(),
+						backgroundColor: tint(COLORS.primary, 0.7),
 						borderColor: null,
 					},
 					active: {
 						color: '#fff',
-						backgroundColor: Color('white')
-							.mix(Color(COLORS.primary), 0.5)
-							.hex(),
+						backgroundColor: tint(COLORS.primary, 0.5),
 						borderColor: null,
 					},
 				},
@@ -120,16 +116,12 @@ export default {
 					},
 					hover: {
 						color: '#fff',
-						backgroundColor: Color('white')
-							.mix(Color(COLORS.primary), 0.7)
-							.hex(),
+						backgroundColor: tint(COLORS.primary, 0.7),
 						borderColor: null,
 					},
 					active: {
 						color: '#fff',
-						backgroundColor: Color('white')
-							.mix(Color(COLORS.primary), 0.5)
-							.hex(),
+						backgroundColor: tint(COLORS.primary, 0.5),
 						borderColor: null,
 					},
 				},
@@ -143,16 +135,12 @@ export default {
 					},
 					hover: {
 						color: null,
-						backgroundColor: Color('white')
-							.mix(Color(COLORS.hero), 0.7)
-							.hex(),
+						backgroundColor: tint(COLORS.hero, 0.7),
 						borderColor: null,
 					},
 					active: {
 						color: '#fff',
-						backgroundColor: Color('white')
-							.mix(Color(COLORS.hero), 0.5)
-							.hex(),
+						backgroundColor: tint(COLORS.hero, 0.5),
 						borderColor: null,
 					},
 				},
@@ -164,16 +152,12 @@ export default {
 					},
 					hover: {
 						color: '#fff',
-						backgroundColor: Color('white')
-							.mix(Color(COLORS.hero), 0.7)
-							.hex(),
+						backgroundColor: tint(COLORS.hero, 0.7),
 						borderColor: null,
 					},
 					active: {
 						color: '#fff',
-						backgroundColor: Color('white')
-							.mix(Color(COLORS.hero), 0.5)
-							.hex(),
+						backgroundColor: tint(COLORS.hero, 0.5),
 						borderColor: null,
 					},
 				},
@@ -187,16 +171,12 @@ export default {
 					},
 					hover: {
 						color: null,
-						backgroundColor: Color('white')
-							.mix(Color(COLORS.neutral), 0.7)
-							.hex(),
+						backgroundColor: tint(COLORS.neutral, 0.7),
 						borderColor: null,
 					},
 					active: {
 						color: '#fff',
-						backgroundColor: Color('white')
-							.mix(Color(COLORS.neutral), 0.5)
-							.hex(),
+						backgroundColor: tint(COLORS.neutral, 0.5),
 						borderColor: null,
 					},
 				},
@@ -208,16 +188,12 @@ export default {
 					},
 					hover: {
 						color: '#fff',
-						backgroundColor: Color('white')
-							.mix(Color(COLORS.neutral), 0.7)
-							.hex(),
+						backgroundColor: tint(COLORS.neutral, 0.7),
 						borderColor: null,
 					},
 					active: {
 						color: '#fff',
-						backgroundColor: Color('white')
-							.mix(Color(COLORS.neutral), 0.5)
-							.hex(),
+						backgroundColor: tint(COLORS.neutral, 0.5),
 						borderColor: null,
 					},
 				},
@@ -321,12 +297,8 @@ export default {
 				},
 				hover: {
 					color: null,
-					backgroundColor: Color('white')
-						.mix(Color(COLORS.primary), 0.5)
-						.hex(),
-					borderColor: Color('white')
-						.mix(Color(COLORS.primary), 0.5)
-						.hex(),
+					backgroundColor: tint(COLORS.primary, 0.5),
+					borderColor: tint(COLORS.primary, 0.5),
 				},
 			},
 			hero: {
@@ -337,12 +309,8 @@ export default {
 				},
 				hover: {
 					color: null,
-					backgroundColor: Color('white')
-						.mix(Color(COLORS.hero), 0.5)
-						.hex(),
-					borderColor: Color('white')
-						.mix(Color(COLORS.hero), 0.5)
-						.hex(),
+					backgroundColor: tint(COLORS.hero, 0.5),
+					borderColor: tint(COLORS.hero, 0.5),
 				},
 			},
 			neutral: {
@@ -353,12 +321,8 @@ export default {
 				},
 				hover: {
 					color: null,
-					backgroundColor: Color('white')
-						.mix(Color(COLORS.neutral), 0.5)
-						.hex(),
-					borderColor: Color('white')
-						.mix(Color(COLORS.neutral), 0.5)
-						.hex(),
+					backgroundColor: tint(COLORS.neutral, 0.5),
+					borderColor: tint(COLORS.neutral, 0.5),
 				},
 			},
 			faint: {
@@ -381,12 +345,8 @@ export default {
 				},
 				hover: {
 					color: null,
-					backgroundColor: Color('white')
-						.mix(Color(COLORS.success), 0.5)
-						.hex(),
-					borderColor: Color('white')
-						.mix(Color(COLORS.success), 0.5)
-						.hex(),
+					backgroundColor: tint(COLORS.success, 0.5),
+					borderColor: tint(COLORS.success, 0.5),
 				},
 			},
 			information: {
@@ -397,12 +357,8 @@ export default {
 				},
 				hover: {
 					color: null,
-					backgroundColor: Color('white')
-						.mix(Color(COLORS.information), 0.5)
-						.hex(),
-					borderColor: Color('white')
-						.mix(Color(COLORS.information), 0.5)
-						.hex(),
+					backgroundColor: tint(COLORS.information, 0.5),
+					borderColor: tint(COLORS.information, 0.5),
 				},
 			},
 			warning: {
@@ -413,12 +369,8 @@ export default {
 				},
 				hover: {
 					color: null,
-					backgroundColor: Color('white')
-						.mix(Color(COLORS.warning), 0.5)
-						.hex(),
-					borderColor: Color('white')
-						.mix(Color(COLORS.warning), 0.5)
-						.hex(),
+					backgroundColor: tint(COLORS.warning, 0.5),
+					borderColor: tint(COLORS.warning, 0.5),
 				},
 			},
 			danger: {
@@ -429,12 +381,8 @@ export default {
 				},
 				hover: {
 					color: null,
-					backgroundColor: Color('white')
-						.mix(Color(COLORS.danger), 0.5)
-						.hex(),
-					borderColor: Color('white')
-						.mix(Color(COLORS.danger), 0.5)
-						.hex(),
+					backgroundColor: tint(COLORS.danger, 0.5),
+					borderColor: tint(COLORS.danger, 0.5),
 				},
 			},
 		},

--- a/brands/WBG/tokens/utils.js
+++ b/brands/WBG/tokens/utils.js
@@ -1,0 +1,6 @@
+import Color from 'color';
+
+export const tint = (color, amount) =>
+	Color('white')
+		.mix(Color(color), amount)
+		.hex();


### PR DESCRIPTION
Simplifies the token files by moving the Color dependency tint logic into a reusable utility function

Also, reordered the STG token structure to match the other brand's (`label:` was out of order)