### PR TITLE
fix(theme): remove focus outline none

### DIFF
--- a/components/core/src/Theme.js
+++ b/components/core/src/Theme.js
@@ -30,12 +30,6 @@ export const GEL = ({ brand, ...props }) => {
 					*:after {
 						box-sizing: border-box;
 					}
-
-					// Disable default :focus styling
-					// (we will provide our own via our special '.is-keyboarduser' wrapper class)
-					:focus {
-						outline: none;
-					}
 				`}
 			/>
 			<ThemeContext.Provider value={brand} {...props} />


### PR DESCRIPTION
We shouldn't be removing the default focus styling until we implement it. 