### PR TITLE
Remove document 10px fontSize reset

### DIFF
--- a/components/core/src/Core.js
+++ b/components/core/src/Core.js
@@ -3,7 +3,7 @@
 import React, { useContext } from 'react';
 import { Global, jsx } from '@emotion/core';
 import merge from 'lodash.merge';
-import { useTheme, UserModeContext } from './Theme';
+import { useTheme } from './Theme';
 import { paint } from './utils';
 
 export const Core = ({ children }) => {

--- a/components/core/src/Core.js
+++ b/components/core/src/Core.js
@@ -152,16 +152,11 @@ export const Core = ({ children }) => {
 
 	// Typography styling
 	const styleTypography = {
-		// Document
-		html: {
-			fontSize: '62.5%', //10px
-		},
-
 		// Global type styling
 		body: {
 			fontFamily: bodyFont,
 			fontWeight: 400,
-			fontSize: '1.4rem', // (14px)
+			fontSize: '0.875rem', // (14px)
 			lineHeight: 1.428571429,
 			color: COLORS.text,
 			fontFeatureSettings: '"liga" 1', // Enable OpenType ligatures in IE
@@ -191,7 +186,7 @@ export const Core = ({ children }) => {
 
 		// Paragraphs
 		p: {
-			margin: '1.2rem 0',
+			margin: '0.75rem 0', //12px 0
 		},
 
 		// Definition lists
@@ -214,7 +209,7 @@ export const Core = ({ children }) => {
 		},
 
 		blockquote: {
-			fontSize: '1.6rem',
+			fontSize: '1rem',
 			fontWeight: 300,
 		},
 
@@ -243,8 +238,8 @@ export const Core = ({ children }) => {
 	const styleTextExtensions = {
 		// Lead text
 		'.lead': {
-			marginBottom: '2.1rem',
-			fontSize: ['1.6rem', '1.8rem'],
+			marginBottom: '1.3125rem',
+			fontSize: ['1rem', '1.125rem'],
 			fontWeight: 300,
 			lineHeight: 1.4,
 		},

--- a/helpers/example/index.js
+++ b/helpers/example/index.js
@@ -91,15 +91,15 @@ const App = ({ components, packageName }) => {
 
 						<SidebarSwitcher>
 							{Object.keys(BRANDS).map(b => {
-								const checked = brand === b;
+								const isChecked = brand === b;
 								return (
-									<SidebarSwitch key={b} isChecked={checked}>
+									<SidebarSwitch key={b} checked={isChecked}>
 										<input
 											name="brand"
 											type="radio"
 											onChange={e => setBrand(b)}
 											value={b}
-											checked={checked}
+											checked={isChecked}
 										/>
 										{b}
 									</SidebarSwitch>
@@ -312,14 +312,14 @@ const SidebarSwitcher = props => (
 		{...props}
 	/>
 );
-const SidebarSwitch = ({ isChecked, ...props }) => (
+const SidebarSwitch = ({ checked, ...props }) => (
 	<label
 		css={{
 			alignItems: 'center',
 			borderTop: '1px solid',
-			borderTopColor: isChecked ? '#1F252C' : 'rgba(0, 0, 0, 0.1)',
+			borderTopColor: checked ? '#1F252C' : 'rgba(0, 0, 0, 0.1)',
 			boxSizing: 'border-box',
-			color: isChecked ? 'inherit' : '#1F252C',
+			color: checked ? 'inherit' : '#1F252C',
 			cursor: 'pointer',
 			flex: 1,
 			fontWeight: 500,

--- a/helpers/example/index.js
+++ b/helpers/example/index.js
@@ -255,8 +255,8 @@ const SidebarLink = ({ primaryColor, ...props }) => (
 			color: primaryColor,
 			display: 'block',
 			fontWeight: 500,
-			padding: '1rem 2rem',
-			fontSize: '1.6rem',
+			padding: '0.625rem 1.25rem',
+			fontSize: '1rem',
 			textDecoration: 'none',
 
 			':hover, :focus': {
@@ -287,8 +287,8 @@ const SidebarTitle = props => (
 			color: 'inherit',
 			display: 'block',
 			fontWeight: 500,
-			fontSize: '2rem',
-			padding: '2rem',
+			fontSize: '1.25rem',
+			padding: '1.25rem',
 			textDecoration: 'none',
 
 			':hover, :focus': {
@@ -307,7 +307,7 @@ const SidebarSwitcher = props => (
 	<div
 		css={{
 			display: 'flex',
-			fontSize: '1.3rem',
+			fontSize: '0.8125rem',
 		}}
 		{...props}
 	/>
@@ -324,8 +324,8 @@ const SidebarSwitch = ({ isChecked, ...props }) => (
 			flex: 1,
 			fontWeight: 500,
 			justifyContent: 'center',
-			paddingBottom: '1.2rem',
-			paddingTop: '1.2rem',
+			paddingBottom: '0.75rem',
+			paddingTop: '0.75rem',
 			textAlign: 'center',
 
 			input: {


### PR DESCRIPTION
Reverts the document back to a 16px font-size default

1rem = 16px

Also changes `isChecked` props to `checked` so they're inline with where we're going with boolean prop naming throughout.

## Note
The 'focusable elements' example is broken. Fixed with updates to Button, yet to merge (WIP).