### PR TITLE
Update Alert

### DIFF
--- a/components/alert/examples/30-dismissible.js
+++ b/components/alert/examples/30-dismissible.js
@@ -10,23 +10,23 @@ function Example({ brand }) {
 		<GEL brand={brand}>
 			<Intopia />
 
-			<Alert look="success" closable>
+			<Alert look="success" dismissible>
 				<strong>Well done!</strong> You successfully read this important alert message. Hey neato, I
 				can be closed. <a href="#">Link</a>
 			</Alert>
-			<Alert look="info" closable>
+			<Alert look="info" dismissible>
 				<strong>Heads up!</strong> This alert needs your attention, but it’s not super important.
 				Hey neato, I can be closed. <a href="#">Link</a>
 			</Alert>
-			<Alert look="warning" closable>
+			<Alert look="warning" dismissible>
 				<strong>Warning!</strong> Better check yourself, you’re not looking too good. Hey neato, I
 				can be closed. <a href="#">Link</a>
 			</Alert>
-			<Alert look="danger" closable>
+			<Alert look="danger" dismissible>
 				<strong>Oh snap!</strong> Change a few things up and try submitting again. Hey neato, I can
 				be closed. <a href="#">Link</a>
 			</Alert>
-			<Alert look="system" closable>
+			<Alert look="system" dismissible>
 				<strong>System Error 8942:</strong> The server is no responding. Please try again later.
 				Sorry for the inconvenience. Hey neato, I can be closed. <a href="#">Link</a>
 			</Alert>

--- a/components/alert/examples/40-local-tokens.js
+++ b/components/alert/examples/40-local-tokens.js
@@ -6,7 +6,7 @@ import { Alert } from '@westpac/alert';
 
 import { Intopia } from '../../../helpers/example/components/Intopia.js';
 
-const CloseBtnNew = ({ onClose, icon: Icon, closable, look, ...rest }) => (
+const CloseBtnNew = ({ onClose, icon: Icon, dismissible, look, ...rest }) => (
 	<button onClick={() => onClose()} {...rest}>
 		Close <Icon />
 	</button>
@@ -43,7 +43,7 @@ function Example({ brand }) {
 				This is a default alert. <a href="#">Link</a>
 			</Alert>
 
-			<Alert look="system" heading="System Error 8942" closable>
+			<Alert look="system" heading="System Error 8942" dismissible>
 				The server is no responding. Please try again later. Sorry for the inconvenience. Hey neato,
 				I can be closed. <a href="#">Link</a>
 			</Alert>
@@ -66,7 +66,7 @@ function Example({ brand }) {
 			<hr />
 
 			<h3>Alert heading</h3>
-			<Alert look="success" closable>
+			<Alert look="success" dismissible>
 				<strong>Well done!</strong> You successfully read this important alert message. Hey neato, I
 				can be closed. <a href="#">Link</a>
 			</Alert>

--- a/components/alert/src/Alert.js
+++ b/components/alert/src/Alert.js
@@ -13,11 +13,11 @@ import pkg from '../package.json';
 // Overwrite component
 // ==============================
 
-const CloseBtn = ({ onClose, icon, look, closable, ...rest }) => (
+const CloseBtn = ({ onClose, icon, look, dismissible, ...rest }) => (
 	<Button onClick={() => onClose()} iconAfter={icon} look="link" {...rest} />
 );
 
-const BodyHeading = ({ tag, children, closable, ...rest }) => (
+const BodyHeading = ({ tag, children, dismissible, ...rest }) => (
 	<Heading size={7} tag={tag} {...rest}>
 		{children}
 	</Heading>
@@ -27,7 +27,15 @@ const BodyHeading = ({ tag, children, closable, ...rest }) => (
 // Component
 // ==============================
 
-export const Alert = ({ look, closable, icon: Icon, heading, headingTag, children, ...rest }) => {
+export const Alert = ({
+	look,
+	dismissible,
+	icon: Icon,
+	heading,
+	headingTag,
+	children,
+	...rest
+}) => {
 	const { COLORS, SPACING, [pkg.name]: brandOverrides } = useBrand();
 	const mq = useMediaQuery();
 	const [open, setOpen] = useState(true);
@@ -90,7 +98,7 @@ export const Alert = ({ look, closable, icon: Icon, heading, headingTag, childre
 			<div
 				css={mq({
 					marginBottom: '1.3125rem',
-					padding: ['1.125rem', closable ? `1.125rem 1.875rem 1.125rem 1.125rem` : '1.125rem'],
+					padding: ['1.125rem', dismissible ? `1.125rem 1.875rem 1.125rem 1.125rem` : '1.125rem'],
 					position: 'relative',
 					display: [null, 'flex'],
 					zIndex: 1,
@@ -105,12 +113,12 @@ export const Alert = ({ look, closable, icon: Icon, heading, headingTag, childre
 				})}
 				{...rest}
 			>
-				{closable && (
+				{dismissible && (
 					<overrides.CloseBtn
 						onClose={() => setOpen(false)}
 						icon={CloseIcon}
 						look={look}
-						closable={closable}
+						dismissible={dismissible}
 						css={mq({
 							color: 'inherit',
 							position: ['relative', 'absolute'],
@@ -155,7 +163,7 @@ export const Alert = ({ look, closable, icon: Icon, heading, headingTag, childre
 							tag={headingTag}
 							css={{ marginBottom: SPACING(2) }}
 							look={look}
-							closable={closable}
+							dismissible={dismissible}
 						>
 							{heading}
 						</overrides.Heading>
@@ -178,9 +186,9 @@ Alert.propTypes = {
 	look: PropTypes.oneOf(['success', 'info', 'warning', 'danger', 'system']).isRequired,
 
 	/**
-	 * Enable closable mode
+	 * Enable dismissible mode
 	 */
-	closable: PropTypes.bool.isRequired,
+	dismissible: PropTypes.bool.isRequired,
 
 	/**
 	 * Alert icon.
@@ -207,6 +215,6 @@ Alert.propTypes = {
 
 Alert.defaultProps = {
 	look: 'info',
-	closable: false,
+	dismissible: false,
 	headingTag: 'h2',
 };

--- a/components/alert/src/Alert.js
+++ b/components/alert/src/Alert.js
@@ -162,7 +162,6 @@ export const Alert = ({
 						<overrides.Heading
 							tag={headingTag}
 							css={{ marginBottom: SPACING(2) }}
-							look={look}
 							dismissible={dismissible}
 						>
 							{heading}


### PR DESCRIPTION
Update: Renaming `closable` prop as `dismissible`

Fix: Heading doesn't take a 'look' prop (not used or required; CSS `color:inherit;` looks after heading colour)... see screenshot below:

<img width="1016" alt="Screen Shot 2019-11-29 at 2 53 35 pm" src="https://user-images.githubusercontent.com/2049709/69842615-0b3c3900-12b8-11ea-93b0-3e382a3e66df.png">