### PR TITLE
Fix Tabcordion

### DIFF
--- a/components/tabcordion/examples/10-mode.js
+++ b/components/tabcordion/examples/10-mode.js
@@ -7,7 +7,7 @@ function Example({ brand }) {
 	return (
 		<GEL brand={brand}>
 			<h3>Responsive</h3>
-			<Tabcordion>
+			<Tabcordion mode="responsive">
 				<Tab text="Rabbit hole">
 					‘It was much pleasanter at home,’ thought poor Alice, ‘when one wasn’t always growing
 					larger and smaller, and being ordered about by mice and rabbits. I almost wish I hadn’t

--- a/components/tabcordion/examples/20-look.js
+++ b/components/tabcordion/examples/20-look.js
@@ -6,7 +6,53 @@ import { Tab, Tabcordion } from '@westpac/tabcordion';
 function Example({ brand }) {
 	return (
 		<GEL brand={brand}>
-			<h3>Soft</h3>
+			<h2>Soft</h2>
+			<h3>Accordion</h3>
+			<Tabcordion mode="accordion" look="soft">
+				<Tab text="Rabbit hole">
+					‘It was much pleasanter at home,’ thought poor Alice, ‘when one wasn’t always growing
+					larger and smaller, and being ordered about by mice and rabbits. I almost wish I hadn’t
+					gone down that rabbit-hole — and yet — and yet — it’s rather curious, you know, this sort
+					of life! I do wonder what can have happened to me! When I used to read fairy-tales, I
+					fancied that kind of thing never happened, and now here I am in the middle of one! There
+					ought to be a book written about me, that there ought! And when I grow up, I’ll write one.
+				</Tab>
+				<Tab text="Flamingo">
+					The chief difficulty Alice found at first was in managing her flamingo: she succeeded in
+					getting its body tucked away, comfortably enough, under her arm, with its legs hanging
+					down, but generally, just as she had got its neck nicely straightened out, and was going
+					to give the hedgehog a blow with its head, it would twist itself round and look up in her
+					face, with such a puzzled expression that she could not help bursting out laughing: and
+					when she had got its head down, and was going to begin again, it was very provoking to
+					find that the hedgehog had unrolled itself, and was in the act of crawling away: besides
+					all this, there was generally a ridge or furrow in the way wherever she wanted to send the
+					hedgehog to, and, as the doubled-up soldiers were always getting up and walking off to
+					other parts of the ground, Alice soon came to the conclusion that it was a very difficult
+					game indeed.
+				</Tab>
+				<Tab text="Caterpillar">
+					The Caterpillar and Alice looked at each other for some time in silence: at last the
+					Caterpillar took the hookah out of its mouth, and addressed her in a languid, sleepy
+					voice.
+					<br />
+					‘Who are you?’ said the Caterpillar.
+					<br />
+					This was not an encouraging opening for a conversation. Alice replied, rather shyly, ‘I —
+					I hardly know, sir, just at present — at least I know who I was when I got up this
+					morning, but I think I must have been changed several times since then.’
+					<br />
+					‘What do you mean by that?’ said the Caterpillar sternly. ‘Explain yourself!’
+					<br />
+					‘I can’t explain myself, I’m afraid, sir’ said Alice, ’because I’m not myself, you see.’
+					<br />
+					‘I don’t see,’ said the Caterpillar.
+					<br />
+					‘I’m afraid I can’t put it more clearly,’ Alice replied very politely, ‘for I can’t
+					understand it myself to begin with; and being so many different sizes in a day is very
+					confusing.’
+				</Tab>
+			</Tabcordion>
+			<h3>Tabs</h3>
 			<Tabcordion mode="tabs" look="soft">
 				<Tab text="Rabbit hole">
 					‘It was much pleasanter at home,’ thought poor Alice, ‘when one wasn’t always growing
@@ -51,7 +97,56 @@ function Example({ brand }) {
 					confusing.’
 				</Tab>
 			</Tabcordion>
-			<h3>Lego</h3>
+
+			<hr />
+
+			<h2>Lego</h2>
+			<h3>Accordion</h3>
+			<Tabcordion mode="accordion" look="lego">
+				<Tab text="Rabbit hole">
+					‘It was much pleasanter at home,’ thought poor Alice, ‘when one wasn’t always growing
+					larger and smaller, and being ordered about by mice and rabbits. I almost wish I hadn’t
+					gone down that rabbit-hole — and yet — and yet — it’s rather curious, you know, this sort
+					of life! I do wonder what can have happened to me! When I used to read fairy-tales, I
+					fancied that kind of thing never happened, and now here I am in the middle of one! There
+					ought to be a book written about me, that there ought! And when I grow up, I’ll write one.
+				</Tab>
+				<Tab text="Flamingo">
+					The chief difficulty Alice found at first was in managing her flamingo: she succeeded in
+					getting its body tucked away, comfortably enough, under her arm, with its legs hanging
+					down, but generally, just as she had got its neck nicely straightened out, and was going
+					to give the hedgehog a blow with its head, it would twist itself round and look up in her
+					face, with such a puzzled expression that she could not help bursting out laughing: and
+					when she had got its head down, and was going to begin again, it was very provoking to
+					find that the hedgehog had unrolled itself, and was in the act of crawling away: besides
+					all this, there was generally a ridge or furrow in the way wherever she wanted to send the
+					hedgehog to, and, as the doubled-up soldiers were always getting up and walking off to
+					other parts of the ground, Alice soon came to the conclusion that it was a very difficult
+					game indeed.
+				</Tab>
+				<Tab text="Caterpillar">
+					The Caterpillar and Alice looked at each other for some time in silence: at last the
+					Caterpillar took the hookah out of its mouth, and addressed her in a languid, sleepy
+					voice.
+					<br />
+					‘Who are you?’ said the Caterpillar.
+					<br />
+					This was not an encouraging opening for a conversation. Alice replied, rather shyly, ‘I —
+					I hardly know, sir, just at present — at least I know who I was when I got up this
+					morning, but I think I must have been changed several times since then.’
+					<br />
+					‘What do you mean by that?’ said the Caterpillar sternly. ‘Explain yourself!’
+					<br />
+					‘I can’t explain myself, I’m afraid, sir’ said Alice, ’because I’m not myself, you see.’
+					<br />
+					‘I don’t see,’ said the Caterpillar.
+					<br />
+					‘I’m afraid I can’t put it more clearly,’ Alice replied very politely, ‘for I can’t
+					understand it myself to begin with; and being so many different sizes in a day is very
+					confusing.’
+				</Tab>
+			</Tabcordion>
+			<h3>Tabs</h3>
 			<Tabcordion mode="tabs" look="lego">
 				<Tab text="Rabbit hole">
 					‘It was much pleasanter at home,’ thought poor Alice, ‘when one wasn’t always growing

--- a/components/tabcordion/examples/40-configurable.js
+++ b/components/tabcordion/examples/40-configurable.js
@@ -52,7 +52,7 @@ function Example({ brand }) {
 				</Checkbox>
 			</Row>
 
-			<Tabcordion look={look} justifyTabs={justify} mode={mode}>
+			<Tabcordion look={look} justify={justify} mode={mode}>
 				<Tab text="Rabbit hole">
 					‘It was much pleasanter at home,’ thought poor Alice, ‘when one wasn’t always growing
 					larger and smaller, and being ordered about by mice and rabbits. I almost wish I hadn’t

--- a/components/tabcordion/examples/50-local-tokens.js
+++ b/components/tabcordion/examples/50-local-tokens.js
@@ -84,7 +84,7 @@ function Example({ brand }) {
 	return (
 		<GEL brand={overridesWithTokens}>
 			<h3>Responsive</h3>
-			<Tabcordion>
+			<Tabcordion mode="responsive">
 				{data.map(t => (
 					<Tab key={t.text} text={t.text}>
 						{t.content}

--- a/components/tabcordion/examples/50-local-tokens.js
+++ b/components/tabcordion/examples/50-local-tokens.js
@@ -11,7 +11,7 @@ const Panel = forwardRef(({ last, selected, ...props }, ref) => {
 	);
 });
 
-const TabItem = ({ selected, justify, last, ...props }) => {
+const TabItem = forwardRef(({ selected, justify, last, ...props }, ref) => {
 	return (
 		<button
 			css={{
@@ -39,7 +39,7 @@ const TabItem = ({ selected, justify, last, ...props }) => {
 			{...props}
 		/>
 	);
-};
+});
 
 const AccordionLabel = ({ last, selected, ...props }) => {
 	return (
@@ -93,7 +93,7 @@ function Example({ brand }) {
 			</Tabcordion>
 
 			<h3>Always accordion</h3>
-			<Tabcordion mode="accordion" instanceId="always-accordion">
+			<Tabcordion mode="accordion" instanceIdPrefix="always-accordion">
 				{data.map(t => (
 					<Tab key={t.text} text={t.text}>
 						{t.content}
@@ -102,7 +102,7 @@ function Example({ brand }) {
 			</Tabcordion>
 
 			<h3>Always tabs</h3>
-			<Tabcordion mode="tabs" instanceId="always-tabs">
+			<Tabcordion mode="tabs" instanceIdPrefix="always-tabs">
 				{data.map(t => (
 					<Tab key={t.text} text={t.text}>
 						{t.content}

--- a/components/tabcordion/src/Tab.js
+++ b/components/tabcordion/src/Tab.js
@@ -82,13 +82,13 @@ Tab.propTypes = {
 // Overrides & Styled Components
 // ==============================
 const Panel = forwardRef(({ look, last, selected, mode, ...props }, ref) => {
-	const { COLORS: colors, PACKS: packs } = useBrand();
+	const { COLORS } = useBrand();
 	const styles =
 		mode === 'accordion'
 			? {
 					lego: {
 						borderLeftWidth: '0.375rem',
-						borderLeftColor: colors.border,
+						borderLeftColor: COLORS.border,
 					},
 					soft: last
 						? {
@@ -102,14 +102,11 @@ const Panel = forwardRef(({ look, last, selected, mode, ...props }, ref) => {
 		<div
 			ref={ref}
 			css={{
-				borderLeft: `1px solid ${colors.border}`,
-				borderRight: `1px solid ${colors.border}`,
-				borderBottom: (mode === 'tabs' || last) && `1px solid ${colors.border}`,
-				borderTop: mode === 'tabs' && `1px solid ${colors.border}`,
+				borderLeft: `1px solid ${COLORS.border}`,
+				borderRight: `1px solid ${COLORS.border}`,
+				borderBottom: (mode === 'tabs' || last) && `1px solid ${COLORS.border}`,
+				borderTop: mode === 'tabs' && `1px solid ${COLORS.border}`,
 				padding: '1.5rem 3.22%',
-				':focus': {
-					// color: packs.link.color,
-				},
 				...styles[look],
 			}}
 			{...props}
@@ -118,13 +115,13 @@ const Panel = forwardRef(({ look, last, selected, mode, ...props }, ref) => {
 });
 
 const AccordionLabel = ({ look, last, hidden, ...props }) => {
-	const { COLORS: colors } = useBrand();
+	const { COLORS } = useBrand();
 	const styles = {
 		soft: {
-			borderBottom: !hidden && `1px solid ${colors.border}`,
+			borderBottom: !hidden && `1px solid ${COLORS.border}`,
 			...(last &&
 				hidden && {
-					borderBottom: `1px solid ${colors.border}`,
+					borderBottom: `1px solid ${COLORS.border}`,
 					borderBottomLeftRadius: '0.1875rem',
 					borderBottomRightRadius: '0.1875rem',
 				}),
@@ -134,11 +131,11 @@ const AccordionLabel = ({ look, last, hidden, ...props }) => {
 			},
 		},
 		lego: {
-			borderBottom: !hidden && `1px solid ${colors.border}`,
+			borderBottom: !hidden && `1px solid ${COLORS.border}`,
 			borderLeftWidth: '6px',
-			borderLeftColor: !hidden ? colors.border : colors.hero,
+			borderLeftColor: !hidden ? COLORS.border : COLORS.hero,
 			':last-of-type': {
-				borderBottom: `1px solid ${colors.border}`,
+				borderBottom: `1px solid ${COLORS.border}`,
 			},
 		},
 	};
@@ -146,11 +143,11 @@ const AccordionLabel = ({ look, last, hidden, ...props }) => {
 		<button
 			css={{
 				alignItems: 'center',
-				backgroundColor: colors.background,
+				backgroundColor: COLORS.background,
 				border: 0,
-				borderTop: `1px solid ${colors.border}`,
-				borderLeft: `1px solid ${colors.border}`,
-				borderRight: `1px solid ${colors.border}`,
+				borderTop: `1px solid ${COLORS.border}`,
+				borderLeft: `1px solid ${COLORS.border}`,
+				borderRight: `1px solid ${COLORS.border}`,
 				cursor: 'pointer',
 				display: 'flex',
 				fontSize: '1rem',

--- a/components/tabcordion/src/Tab.js
+++ b/components/tabcordion/src/Tab.js
@@ -136,7 +136,7 @@ const AccordionLabel = ({ look, last, hidden, ...props }) => {
 		lego: {
 			borderBottom: !hidden && `1px solid ${colors.border}`,
 			borderLeftWidth: '6px',
-			borderLeftColor: !hidden ? colors.border : colors.hero.default,
+			borderLeftColor: !hidden ? colors.border : colors.hero,
 			':last-of-type': {
 				borderBottom: `1px solid ${colors.border}`,
 			},

--- a/components/tabcordion/src/Tabcordion.js
+++ b/components/tabcordion/src/Tabcordion.js
@@ -175,7 +175,7 @@ Tabcordion.propTypes = {
 	/** Whether or not tabs should stretch full width */
 	justify: PropTypes.bool,
 	/** Lock the mode to either "accordion" or "tabs". The default is responsive. */
-	mode: PropTypes.oneOf(['accordion', 'responsive', 'tabs']),
+	mode: PropTypes.oneOf(['responsive', 'accordion', 'tabs']),
 };
 Tabcordion.defaultProps = {
 	look: 'soft',

--- a/components/tabcordion/src/Tabcordion.js
+++ b/components/tabcordion/src/Tabcordion.js
@@ -174,7 +174,7 @@ Tabcordion.propTypes = {
 	instanceIdPrefix: PropTypes.string,
 	/** Whether or not tabs should stretch full width */
 	justify: PropTypes.bool,
-	/** Lock the mode to either "accordion" or "tabs". The default is responsive. */
+	/** Lock the mode to either "accordion" or "tabs". The default is "responsive". */
 	mode: PropTypes.oneOf(['responsive', 'accordion', 'tabs']),
 };
 Tabcordion.defaultProps = {
@@ -200,23 +200,23 @@ const TabRow = forwardRef((props, ref) => (
 ));
 
 const TabItem = forwardRef(({ look, justify, selected, last, ...props }, ref) => {
-	const { COLORS: colors } = useBrand();
+	const { COLORS } = useBrand();
 
 	const styles = {
 		soft: {
-			backgroundColor: selected ? '#fff' : colors.background,
+			backgroundColor: selected ? '#fff' : COLORS.background,
 			borderTopLeftRadius: '0.1875rem',
 			borderTopRightRadius: '0.1875rem',
-			border: `1px solid ${colors.border}`,
+			border: `1px solid ${COLORS.border}`,
 			borderBottom: 0,
-			color: colors.neutral,
+			color: COLORS.neutral,
 			marginBottom: selected && '-1px',
 		},
 		lego: {
-			backgroundColor: selected ? '#fff' : colors.hero,
-			border: `1px solid ${selected ? colors.border : 'transparent'}`,
+			backgroundColor: selected ? '#fff' : COLORS.hero,
+			border: `1px solid ${selected ? COLORS.border : 'transparent'}`,
 			borderBottom: 0,
-			color: selected ? colors.text : '#fff',
+			color: selected ? COLORS.text : '#fff',
 			marginBottom: selected ? '-1px' : '0.125rem',
 		},
 	};


### PR DESCRIPTION
• chore(tabcordion): remove unnecessary named destructured vars, tidy up

• fix(tabcordion): fix lego accordion borderLeftColor

• chore(tabcordion): rename appearance example (now look), update examples to use responsive mode explicitly

• fix(tabcordion): fix incorrect justify prop name in configurable example

• fix(tabcordion): fix forwardRef and instanceIdPrefix prop issue in local tokens example