### PR TITLE
Fix brand query string redirect bug

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -23,8 +23,6 @@ module.exports = {
 								'last 2 firefox versions',
 								'last 2 safari versions',
 								'last 2 edge versions',
-								'ie 10',
-								'ie 11',
 							],
 						},
 					},

--- a/website/src/pages/_app.js
+++ b/website/src/pages/_app.js
@@ -68,10 +68,17 @@ GELApp.getInitialProps = async appContext => {
 
 		if (brandCookieMatch) {
 			if (res) {
-				res.writeHead(302, { Location: `${router.asPath}?b=${brandCookieMatch}` });
+				res.writeHead(302, { Location: `${router.asPath.split('?')[0]}?b=${brandCookieMatch}` });
 				res.end();
 			} else {
 				router.push(`${router.asPath.split('?')[0]}?b=${brandCookieMatch}`);
+			}
+		} else {
+			if (res) {
+				res.writeHead(302, { Location: `${router.asPath.split('?')[0]}` });
+				res.end();
+			} else {
+				router.push(`${router.asPath.split('?')[0]}`);
 			}
 		}
 	}


### PR DESCRIPTION
Previously an incorrect querystring for the brand would cause an infinite loop.

Now it will redirect to brand selection page or get the brand from the cookie.