### PR TITLE
fixed spacing and parseInt 

### DIFF
--- a/website/dynamic-blocks/props-table.js
+++ b/website/dynamic-blocks/props-table.js
@@ -57,7 +57,7 @@ function Indent({ level }) {
 
 	return (
 		<span
-			css={{ color: COLORS.muted, margin: `0 0.5em 0 ${parseInt(SPACING(7)) * (level - 1)}em` }}
+			css={{ color: COLORS.muted, margin: `0 0.5em 0 ${SPACING(7, false, '') * (level - 1)}em` }}
 		>
 			└─
 		</span>


### PR DESCRIPTION
`SPACING` actually has an argument that removes the unit, silly Dom