### PR TITLE
Correcting casing for ref to package `@westpac/icon`

### DIFF
--- a/website/src/components/brand-switcher/brand-switcher.js
+++ b/website/src/components/brand-switcher/brand-switcher.js
@@ -17,7 +17,7 @@ import {
 	BTFGStackedLogo,
 	STGDragonLogo,
 } from '@westpac/symbol';
-import { ExpandMoreIcon, ExpandLessIcon } from '@westpac/Icon';
+import { ExpandMoreIcon, ExpandLessIcon } from '@westpac/icon';
 
 import { useBrandSwitcher } from '../providers/brand-switcher';
 


### PR DESCRIPTION
Blocks build on case-sensitive file systems