### PR TITLE
Block editor UI polish

### DIFF
--- a/website/field-content/src/views/editor/block-disclosure-menu.js
+++ b/website/field-content/src/views/editor/block-disclosure-menu.js
@@ -1,7 +1,6 @@
 /** @jsx jsx */
 
 import { forwardRef } from 'react';
-import { createPortal } from 'react-dom';
 import { jsx } from '@emotion/core';
 import { colors, gridSize } from '@arch-ui/theme';
 
@@ -18,14 +17,6 @@ const cancelEvent = event => {
 	event.preventDefault();
 };
 
-const Portal = ({ children }) => {
-	if (typeof window === 'undefined') {
-		return null;
-	}
-
-	return createPortal(children, document.body);
-};
-
 // Disclosure Menu
 // ------------------------------
 
@@ -38,6 +29,7 @@ const Portal = ({ children }) => {
 
 export const BlockDisclosureMenu = forwardRef((props, ref) => (
 	<Dialog
+		portal
 		css={{
 			alignItems: 'center',
 			display: 'flex',
@@ -124,6 +116,7 @@ export const BlockDisclosureMenuButton = ({
 
 export const BlockInsertMenu = forwardRef(({ isOpen, ...props }, ref) => (
 	<Dialog
+		portal
 		css={{
 			display: isOpen ? 'block' : 'none',
 			marginLeft: -12, // align with the block disclosure line
@@ -131,6 +124,11 @@ export const BlockInsertMenu = forwardRef(({ isOpen, ...props }, ref) => (
 			paddingBottom: 4,
 			paddingTop: 4,
 			overflowY: 'auto',
+
+			// bail when no children
+			':empty': {
+				display: 'none',
+			},
 		}}
 		ref={ref}
 		{...props}
@@ -143,12 +141,13 @@ export const BlockInsertMenuItem = ({ icon, text, insertBlock }) => (
 			alignItems: 'center',
 			background: 'none',
 			border: 'none',
-			color: colors.N60,
+			color: colors.N70,
 			cursor: 'pointer',
 			display: 'flex',
 			fontWeight: 500,
 			margin: 0,
 			padding: `${gridSize}px ${gridSize * 2}px`,
+			whiteSpace: 'nowrap',
 			width: '100%',
 
 			// fix some weirdness with content-field "reset", by increasing specificity to avoid `!important`
@@ -164,7 +163,7 @@ export const BlockInsertMenuItem = ({ icon, text, insertBlock }) => (
 		type="button"
 		onClick={insertBlock}
 	>
-		<span css={{ color: colors.N40 }}>{icon}</span>
+		<span>{icon}</span>
 		<span css={{ paddingLeft: gridSize * 2 }}>{text}</span>
 	</button>
 );

--- a/website/field-content/src/views/editor/blocks/link.js
+++ b/website/field-content/src/views/editor/blocks/link.js
@@ -31,14 +31,20 @@ export function Node({ node, attributes, children, isSelected, editor }) {
 
 	return (
 		<Fragment>
-			<a {...attributes} ref={setAnchorRef} css={{ color: 'blue' }} href={href}>
+			<a {...attributes} ref={setAnchorRef} href={href}>
 				{children}
 			</a>
 			{isSelected && (
-				<Popper placement="bottom" referenceElement={anchorRef}>
-					{({ style, ref }) => {
+				<Popper
+					placement="bottom"
+					modifiers={{
+						offset: { enabled: true, offset: gridSize },
+					}}
+					referenceElement={anchorRef}
+				>
+					{({ style, ref, placement }) => {
 						return (
-							<Dialog style={style} ref={ref}>
+							<Dialog portal style={style} ref={ref} data-placement={placement}>
 								<div css={wrapperStyles}>
 									<Input
 										value={inputValue}
@@ -61,7 +67,6 @@ export function Node({ node, attributes, children, isSelected, editor }) {
 										label="Open"
 										rel="noopener"
 										target="_blank"
-										tooltipPlacement="bottom"
 									/>
 									<ToolbarButton
 										label="Unlink"
@@ -133,6 +138,9 @@ export function ToolbarElement({ editor, editorState }) {
 			/>
 			<Popper
 				placement="bottom"
+				modifiers={{
+					offset: { enabled: true, offset: gridSize },
+				}}
 				referenceElement={
 					// the reason we do this rather than having the selection reference be
 					// constant is because the selection reference has some internal state
@@ -146,7 +154,7 @@ export function ToolbarElement({ editor, editorState }) {
 					}
 
 					return (
-						<Dialog style={style} ref={ref}>
+						<Dialog portal style={style} ref={ref}>
 							<form
 								onSubmit={e => {
 									e.stopPropagation();
@@ -200,7 +208,7 @@ const wrapperStyles = {
 const Input = forwardRef((props, ref) => (
 	<input
 		ref={ref}
-		placeholder="Link..."
+		placeholder="http://some.url"
 		onClick={e => {
 			e.stopPropagation(); // stop propagation here so that focus works
 		}}

--- a/website/field-content/src/views/editor/blocks/paragraph.js
+++ b/website/field-content/src/views/editor/blocks/paragraph.js
@@ -4,15 +4,5 @@ import { jsx } from '@emotion/core';
 export let type = 'paragraph';
 
 export function Node({ attributes, children }) {
-	return (
-		<p
-			{...attributes}
-			css={{
-				':first-of-type': { marginTop: 0 },
-				':last-of-type': { marginBottom: 0 },
-			}}
-		>
-			{children}
-		</p>
-	);
+	return <p {...attributes}>{children}</p>;
 }

--- a/website/field-content/src/views/editor/dialog.js
+++ b/website/field-content/src/views/editor/dialog.js
@@ -8,24 +8,17 @@ import { jsx } from '@emotion/core';
 // consistent styles among the UI. Assumes placement styles are applied at
 // runtime.
 
-export const Dialog = forwardRef((props, ref) => (
-	<Portal>
-		<div
-			css={{
-				alignItems: 'center',
-				backgroundColor: 'white',
-				borderRadius: 3,
-				boxShadow: `rgba(9, 30, 66, 0.31) 0px 0px 1px, rgba(9, 30, 66, 0.25) 0px 4px 8px -2px`,
-				position: 'absolute',
-				left: -99999,
-				top: -99999,
-				zIndex: 2,
-			}}
-			ref={ref}
-			{...props}
-		/>
-	</Portal>
-));
+export const Dialog = forwardRef(({ portal = false, ...props }, ref) => {
+	if (portal) {
+		return (
+			<Portal>
+				<DialogElement ref={ref} {...props} />
+			</Portal>
+		);
+	}
+
+	return <DialogElement ref={ref} {...props} />;
+});
 
 const Portal = ({ children }) => {
 	if (typeof window === 'undefined') {
@@ -34,3 +27,18 @@ const Portal = ({ children }) => {
 
 	return createPortal(children, document.body);
 };
+
+const DialogElement = forwardRef((props, ref) => (
+	<div
+		css={{
+			alignItems: 'center',
+			backgroundColor: 'white',
+			borderRadius: 3,
+			boxShadow: `rgba(9, 30, 66, 0.31) 0px 0px 1px, rgba(9, 30, 66, 0.25) 0px 4px 8px -2px`,
+			position: 'absolute',
+			zIndex: 2,
+		}}
+		ref={ref}
+		{...props}
+	/>
+));

--- a/website/field-content/src/views/editor/hooks/useClickOutside.js
+++ b/website/field-content/src/views/editor/hooks/useClickOutside.js
@@ -1,0 +1,41 @@
+import { RefObject, useCallback, useLayoutEffect } from 'react';
+
+/**
+ * @callback MouseHandler
+ * @param {MouseEvent} event - The native event object.
+ * @return {void}
+ */
+
+/**
+ * Watch for click events outside your target refs and handle them.
+ * @param {Object} options - The options object.
+ * @param {MouseHandler} options.handler - Handle a click outside the target refs
+ * @param {RefObject<HTMLElement>[]} options.refs - An array of refs to ignore click events on
+ * @param {boolean} options.listenWhen - When to add/remove event listeners
+ */
+export const useClickOutside = ({ handler, refs, listenWhen }) => {
+	const handleMouseDown = useCallback(
+		event => {
+			// bail on mouse down "inside" any of the provided refs
+			if (refs.some(ref => ref.current && ref.current.contains(event.target))) {
+				return;
+			}
+
+			handler(event);
+		},
+		[handler, refs]
+	);
+
+	// layout effect is not run on the server
+	useLayoutEffect(() => {
+		if (listenWhen) {
+			document.addEventListener('mousedown', handleMouseDown);
+
+			return () => {
+				document.removeEventListener('mousedown', handleMouseDown);
+			};
+		}
+		// NOTE: only call when the value of `listenWhen` changes
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [listenWhen]);
+};

--- a/website/field-content/src/views/editor/hooks/useKeyPress.js
+++ b/website/field-content/src/views/editor/hooks/useKeyPress.js
@@ -14,6 +14,7 @@ import { useCallback, useEffect, useState } from 'react';
  * @param {boolean} options.listenWhen - When to add/remove event listeners
  * @param {KeyboardHandler} options.downHandler - (optional) Handle the key down event
  * @param {KeyboardHandler} options.upHandler - (optional) Handle the key up event
+ * @return {boolean} Whether the target key is down.
  */
 export const useKeyPress = ({ targetKey, downHandler, upHandler, listenWhen }) => {
 	// Keep track of whether the target key is pressed

--- a/website/field-content/src/views/editor/toolbar-components.js
+++ b/website/field-content/src/views/editor/toolbar-components.js
@@ -57,11 +57,15 @@ export const ToolbarButton = forwardRef(
 								marginRight: 2,
 							},
 
-							':hover,:focus': {
+							':hover:enabled,:focus:enabled': {
 								background: colors.N10,
 							},
-							':active': {
+							':active:enabled': {
 								background: colors.N15,
+							},
+
+							':disabled': {
+								cursor: 'default',
 							},
 
 							'[data-state-active="true"]&': {

--- a/website/field-content/src/views/editor/toolbar-components.js
+++ b/website/field-content/src/views/editor/toolbar-components.js
@@ -40,7 +40,7 @@ export const ToolbarButton = forwardRef(
 							border: 0,
 							borderRadius: 3,
 							boxSizing: 'border-box',
-							color: isDisabled ? colors.N40 : colors.N70,
+							color: colors.N70,
 							cursor: 'pointer',
 							display: 'flex',
 							justifyContent: 'center',
@@ -57,14 +57,16 @@ export const ToolbarButton = forwardRef(
 								marginRight: 2,
 							},
 
-							':hover:enabled,:focus:enabled': {
+							':hover,:focus': {
 								background: colors.N10,
 							},
-							':active:enabled': {
+							':active': {
 								background: colors.N15,
 							},
 
 							':disabled': {
+								background: 0,
+								color: colors.N40,
 								cursor: 'default',
 							},
 

--- a/website/field-content/src/views/editor/toolbar-components.js
+++ b/website/field-content/src/views/editor/toolbar-components.js
@@ -39,16 +39,17 @@ export const ToolbarButton = forwardRef(
 							background: 0,
 							border: 0,
 							borderRadius: 3,
+							boxSizing: 'border-box',
 							color: isDisabled ? colors.N40 : colors.N70,
 							cursor: 'pointer',
 							display: 'flex',
 							justifyContent: 'center',
 							outline: 0,
-							padding: 0,
+							padding: `0 ${gridSize / 2}px`,
 
 							// might not work in the future with alternative icons etc.
 							height: ITEM_HEIGHT,
-							width: ITEM_WIDTH,
+							minWidth: ITEM_WIDTH,
 
 							// fix some weirdness with content-field "reset", by increasing specificity to avoid `!important`
 							'button&': {

--- a/website/field-content/src/views/editor/toolbar-icons.js
+++ b/website/field-content/src/views/editor/toolbar-icons.js
@@ -11,12 +11,15 @@ export const ListUnorderedIcon = props => <Svg path={svgPathMap['listUnordered']
 export const StrikethroughIcon = props => <Svg path={svgPathMap['strikeThrough']} {...props} />;
 export const UnderlineIcon = props => <Svg path={svgPathMap['underline']} {...props} />;
 
+export const ArrowDownIcon = props => <Svg path={svgPathMap['arrowDown']} {...props} />;
 export const ExternalIcon = props => <Svg path={svgPathMap['external']} {...props} />;
 export const CrossIcon = props => <Svg path={svgPathMap['cross']} {...props} />;
+export const MoreIcon = props => <Svg path={svgPathMap['more']} {...props} />;
+export const PlusIcon = props => <Svg path={svgPathMap['plus']} {...props} />;
 export const TickIcon = props => <Svg path={svgPathMap['tick']} {...props} />;
 
 const svgPathMap = {
-	// Toolbar Specific
+	// Core
 	// ------------------------------
 
 	// bold B
@@ -58,6 +61,15 @@ const svgPathMap = {
 	// box with arrow pointing out, diagonally up-and-right
 	external:
 		'M10.99 13.99h-9v-9h4.76l2-2H.99c-.55 0-1 .45-1 1v11c0 .55.45 1 1 1h11c.55 0 1-.45 1-1V7.24l-2 2v4.75zm4-14h-5c-.55 0-1 .45-1 1s.45 1 1 1h2.59L7.29 7.28a1 1 0 00-.3.71 1.003 1.003 0 001.71.71l5.29-5.29V6c0 .55.45 1 1 1s1-.45 1-1V1c0-.56-.45-1.01-1-1.01z',
+	// three dots "disclosure"
+	more:
+		'M2 6.03a2 2 0 100 4 2 2 0 100-4zM14 6.03a2 2 0 100 4 2 2 0 100-4zM8 6.03a2 2 0 100 4 2 2 0 100-4z',
+	// arrow down
+	arrowDown:
+		'M12 6.5c0-.28-.22-.5-.5-.5h-7a.495.495 0 00-.37.83l3.5 4c.09.1.22.17.37.17s.28-.07.37-.17l3.5-4c.08-.09.13-.2.13-.33z',
+	// plus or "add"
+	plus:
+		'M13 7H9V3c0-.55-.45-1-1-1s-1 .45-1 1v4H3c-.55 0-1 .45-1 1s.45 1 1 1h4v4c0 .55.45 1 1 1s1-.45 1-1V9h4c.55 0 1-.45 1-1s-.45-1-1-1z',
 	// a tick or "checkmark"
 	tick:
 		'M14 3c-.28 0-.53.11-.71.29L6 10.59l-3.29-3.3a1.003 1.003 0 00-1.42 1.42l4 4c.18.18.43.29.71.29s.53-.11.71-.29l8-8A1.003 1.003 0 0014 3z',

--- a/website/field-content/src/views/editor/toolbar.js
+++ b/website/field-content/src/views/editor/toolbar.js
@@ -86,8 +86,6 @@ export default function Toolbar({ blocks, editor, editorHasFocus, editorState })
 							}}
 						/>
 
-						<ToolbarDivider />
-
 						<InsertMenu
 							blocks={blocks}
 							editor={editor}
@@ -104,7 +102,10 @@ export default function Toolbar({ blocks, editor, editorHasFocus, editorState })
 // ------------------------------
 
 /* This is the dropdown menu shown when a user clicks `InsertBlock` */
-const InsertMenu = ({ blocks, editor, editorState }) => {
+const InsertMenu = ({ blocks, editor }) => {
+	// bail if there aren't any "insertable" blocks
+	if (!Object.keys(blocks).filter(key => blocks[key].Sidebar).length) return null;
+
 	let targetRef = useRef();
 	let menuRef = useRef();
 	let [isOpen, setIsOpen] = useState(false);
@@ -126,47 +127,50 @@ const InsertMenu = ({ blocks, editor, editorState }) => {
 	});
 
 	return (
-		<div css={{ position: 'relative' }}>
-			<ToolbarButton
-				isActive={isOpen}
-				ref={targetRef}
-				label="Insert"
-				icon={
-					<div css={{ display: 'flex' }}>
-						<PlusIcon />
-						<ArrowDownIcon />
-					</div>
-				}
-				onClick={() => {
-					setIsOpen(s => !s);
-				}}
-			/>
-			<Dialog
-				css={{
-					display: isOpen ? 'block' : 'none',
-					maxHeight: 400,
-					paddingBottom: 4,
-					paddingTop: 4,
-					overflowY: 'auto',
-					top: '100%',
-					marginTop: gridSize,
-				}}
-				ref={menuRef}
-				onClick={() => {
-					setIsOpen(false);
-				}}
-			>
-				{Object.keys(blocks).map(key => {
-					let { Sidebar } = blocks[key];
-
-					// only interested in "dynamic-components"
-					if (!blocks[key].withChrome || Sidebar === undefined) {
-						return null;
+		<Fragment>
+			<ToolbarDivider />
+			<div css={{ position: 'relative' }}>
+				<ToolbarButton
+					isActive={isOpen}
+					ref={targetRef}
+					label="Insert"
+					icon={
+						<div css={{ display: 'flex' }}>
+							<PlusIcon />
+							<ArrowDownIcon />
+						</div>
 					}
+					onClick={() => {
+						setIsOpen(s => !s);
+					}}
+				/>
+				<Dialog
+					css={{
+						display: isOpen ? 'block' : 'none',
+						maxHeight: 400,
+						paddingBottom: 4,
+						paddingTop: 4,
+						overflowY: 'auto',
+						top: '100%',
+						marginTop: gridSize,
+					}}
+					ref={menuRef}
+					onClick={() => {
+						setIsOpen(false);
+					}}
+				>
+					{Object.keys(blocks).map(key => {
+						let { Sidebar } = blocks[key];
 
-					return <Sidebar key={key} editor={editor} blocks={blocks} />;
-				})}
-			</Dialog>
-		</div>
+						// only interested in "dynamic-components"
+						if (!blocks[key].withChrome || Sidebar === undefined) {
+							return null;
+						}
+
+						return <Sidebar key={key} editor={editor} blocks={blocks} />;
+					})}
+				</Dialog>
+			</div>
+		</Fragment>
 	);
 };

--- a/website/field-content/src/views/editor/toolbar.js
+++ b/website/field-content/src/views/editor/toolbar.js
@@ -63,6 +63,7 @@ export default function Toolbar({ blocks, editor, editorHasFocus, editorState })
 								<ToolbarButton
 									label={marks[name].label}
 									icon={<Icon />}
+									isDisabled={editorState?.focusBlock?.type === 'dynamic-components'}
 									isActive={editorState.activeMarks.some(mark => mark.type === name)}
 									onClick={() => {
 										editor.toggleMark(name);

--- a/website/field-content/src/views/editor/toolbar.js
+++ b/website/field-content/src/views/editor/toolbar.js
@@ -1,18 +1,21 @@
 /** @jsx jsx */
 
 import { jsx } from '@emotion/core';
-import { Fragment } from 'react';
+import { Fragment, useRef, useState } from 'react';
 
 import { colors, gridSize } from '@arch-ui/theme';
 
+import { Dialog } from './dialog';
 import { marks, markTypes } from './marks';
 import { ToolbarButton, ToolbarDivider } from './toolbar-components';
-import { ClearFormattingIcon } from './toolbar-icons';
+import { ClearFormattingIcon, PlusIcon, ArrowDownIcon } from './toolbar-icons';
+import { useClickOutside } from './hooks/useClickOutside';
+import { useKeyPress } from './hooks';
 
 // NOTE: reduce is used below to allow blocks to replace the toolbar by exposing
 // its own `Toolbar`, this was the case for the `link` block.
 
-export default function Toolbar({ blocks, editor, editorState }) {
+export default function Toolbar({ blocks, editor, editorHasFocus, editorState }) {
 	return (
 		<div
 			css={{
@@ -24,7 +27,7 @@ export default function Toolbar({ blocks, editor, editorState }) {
 				padding: `${gridSize * 2}px 0`,
 				position: 'sticky',
 				top: 0,
-				zIndex: 1,
+				zIndex: 2,
 			}}
 		>
 			{Object.keys(blocks)
@@ -39,6 +42,20 @@ export default function Toolbar({ blocks, editor, editorState }) {
 						);
 					},
 					<Fragment>
+						{/* Block elements, that are injected */}
+						{Object.keys(blocks).map(type => {
+							let ToolbarElement = blocks[type].ToolbarElement;
+
+							// the `withChrome` flag identifies blocks that represent "dynamic-components"
+							if (!blocks[type].withChrome || ToolbarElement === undefined) {
+								return null;
+							}
+
+							return <ToolbarElement key={type} editor={editor} editorState={editorState} />;
+						})}
+
+						<ToolbarDivider />
+
 						{/* Inline "marks", that wrap text */}
 						{Object.keys(marks).map(name => {
 							let Icon = marks[name].icon;
@@ -71,19 +88,85 @@ export default function Toolbar({ blocks, editor, editorState }) {
 
 						<ToolbarDivider />
 
-						{/* Block elements, that are injected */}
-						{Object.keys(blocks).map(type => {
-							let ToolbarElement = blocks[type].ToolbarElement;
-
-							// the `withChrome` flag identifies blocks that represent "dynamic-components"
-							if (!blocks[type].withChrome || ToolbarElement === undefined) {
-								return null;
-							}
-
-							return <ToolbarElement key={type} editor={editor} editorState={editorState} />;
-						})}
+						<InsertMenu
+							blocks={blocks}
+							editor={editor}
+							editorHasFocus={editorHasFocus}
+							editorState={editorState}
+						/>
 					</Fragment>
 				)}
 		</div>
 	);
 }
+
+// Insert Menu
+// ------------------------------
+
+/* This is the dropdown menu shown when a user clicks `InsertBlock` */
+const InsertMenu = ({ blocks, editor, editorState }) => {
+	let targetRef = useRef();
+	let menuRef = useRef();
+	let [isOpen, setIsOpen] = useState(false);
+
+	// close the menu on `Esc` press, and click outside either the target or menu
+	useKeyPress({
+		downHandler: () => {
+			setIsOpen(false);
+		},
+		targetKey: 'Escape',
+		listenWhen: isOpen,
+	});
+	useClickOutside({
+		handler: () => {
+			setIsOpen(false);
+		},
+		refs: [targetRef, menuRef],
+		listenWhen: isOpen,
+	});
+
+	return (
+		<div css={{ position: 'relative' }}>
+			<ToolbarButton
+				isActive={isOpen}
+				ref={targetRef}
+				label="Insert"
+				icon={
+					<div css={{ display: 'flex' }}>
+						<PlusIcon />
+						<ArrowDownIcon />
+					</div>
+				}
+				onClick={() => {
+					setIsOpen(s => !s);
+				}}
+			/>
+			<Dialog
+				css={{
+					display: isOpen ? 'block' : 'none',
+					maxHeight: 400,
+					paddingBottom: 4,
+					paddingTop: 4,
+					overflowY: 'auto',
+					top: '100%',
+					marginTop: gridSize,
+				}}
+				ref={menuRef}
+				onClick={() => {
+					setIsOpen(false);
+				}}
+			>
+				{Object.keys(blocks).map(key => {
+					let { Sidebar } = blocks[key];
+
+					// only interested in "dynamic-components"
+					if (!blocks[key].withChrome || Sidebar === undefined) {
+						return null;
+					}
+
+					return <Sidebar key={key} editor={editor} blocks={blocks} />;
+				})}
+			</Dialog>
+		</div>
+	);
+};

--- a/website/index.js
+++ b/website/index.js
@@ -42,7 +42,7 @@ const apps = [
 	new GraphQLApp(),
 	new AdminUIApp({
 		adminPath: '/admin',
-		// authStrategy,
+		authStrategy,
 		hooks: require.resolve('./admin'),
 	}),
 	new NextApp({ dir: 'src' }),

--- a/website/schema/component.js
+++ b/website/schema/component.js
@@ -6,11 +6,11 @@ const { resolveComponent } = require('../extend-schema');
 const DYNAMIC_BLOCKS_DIR = require.resolve('../dynamic-blocks');
 
 const BLOCKS_CONFIG = [
-	Content.blocks.blockquote,
+	Content.blocks.heading,
 	Content.blocks.orderedList,
 	Content.blocks.unorderedList,
+	Content.blocks.blockquote,
 	Content.blocks.link,
-	Content.blocks.heading,
 	[DynamicComponentsBlock, { components: DYNAMIC_BLOCKS_DIR }],
 ];
 

--- a/website/utils/dynamic-components-view.js
+++ b/website/utils/dynamic-components-view.js
@@ -4,6 +4,7 @@ import { jsx } from '@emotion/core';
 import { Component, Fragment, useMemo, createContext, useContext, useState } from 'react';
 import { Block } from 'slate';
 import { PencilIcon, CheckIcon, TrashcanIcon } from '@arch-ui/icons';
+import { colors, gridSize } from '@arch-ui/theme';
 
 import { type as defaultType } from '../field-content/src/views/editor/blocks/paragraph';
 
@@ -96,7 +97,7 @@ export function Actions({ editor, node }) {
 				onClick={() => {
 					setCurrentlyEditingBlocks(x => ({ ...x, [node.key]: !x[node.key] }));
 				}}
-				title={isEditing ? 'Done editing' : 'Edit component'}
+				title={isEditing ? 'Done editing' : 'Edit block'}
 			>
 				{isEditing ? <CheckIcon /> : <PencilIcon />}
 			</BlockDisclosureMenuButton>
@@ -106,7 +107,7 @@ export function Actions({ editor, node }) {
 				onClick={() => {
 					editor.removeNodeByKey(node.key);
 				}}
-				title="Remove component"
+				title="Remove block"
 			>
 				<TrashcanIcon />
 			</BlockDisclosureMenuButton>
@@ -153,6 +154,7 @@ export function Node({ node, attributes, editor, item }) {
 	}
 	let Component = view[componentName].component;
 	let Editor = view[componentName].editor;
+	let isFocused = editor.value.focusBlock.key === node.key;
 
 	return (
 		<div
@@ -163,19 +165,21 @@ export function Node({ node, attributes, editor, item }) {
 			}}
 		>
 			<ErrorBoundary>
-				{!!Editor && isEditing ? (
-					<Editor
-						item={item}
-						value={node.get('data').get('props')}
-						onChange={dynamicComponentProps => {
-							editor.setNodeByKey(node.key, {
-								data: node.data.set('props', { ...dynamicComponentProps }),
-							});
-						}}
-					/>
-				) : (
-					<Component {...node.get('data').get('props')} context={'admin'} item={item} />
-				)}
+				<BlockLayout isEditing={isEditing} isFocused={isFocused}>
+					{!!Editor && isEditing ? (
+						<Editor
+							item={item}
+							value={node.get('data').get('props')}
+							onChange={dynamicComponentProps => {
+								editor.setNodeByKey(node.key, {
+									data: node.data.set('props', { ...dynamicComponentProps }),
+								});
+							}}
+						/>
+					) : (
+						<Component {...node.get('data').get('props')} context={'admin'} item={item} />
+					)}
+				</BlockLayout>
 			</ErrorBoundary>
 		</div>
 	);
@@ -197,6 +201,33 @@ export let getPlugins = () => [
 		},
 	},
 ];
+
+// Styled Components
+// ------------------------------
+
+// This is the disclosure indicator line to the left of the block
+// Plus the block node itself
+const BlockLayout = ({ children, isEditing = false, isFocused = false }) => {
+	let lineColor = 'transparent';
+	if (isFocused) lineColor = colors.N20;
+	if (isEditing) lineColor = isFocused ? colors.B.base : colors.Y.base;
+
+	return (
+		<span css={{ display: 'flex' }}>
+			<span
+				css={{
+					borderLeft: '4px solid transparent',
+					borderLeftColor: lineColor,
+					boxSizing: 'border-box',
+					flexShrink: 0,
+					marginLeft: -gridSize * 2,
+					width: gridSize * 2,
+				}}
+			/>
+			<span css={{ paddingBottom: 8, flexGrow: 1 }}>{children}</span>
+		</span>
+	);
+};
 
 // Icons for the insert menu
 


### PR DESCRIPTION
The original PR (#274) was closed pre-emptively. This wraps up a lot of the work from there.

- fix selection behaviour between blocks
- move insert menu to the toolbar
- only display the disclosure line for "dynamic-component" blocks
- highlight blocks that were left in "edit-mode"
- provide placeholder text to improve affordance
- disable "marks" for dynamic-components
- only show the insert menu when the appropriate blocks are available