### PR TITLE
Deployment tweak; should prevent `yarn.lock` being modified on deploy

### DIFF
--- a/pm2-post-deploy.sh
+++ b/pm2-post-deploy.sh
@@ -4,7 +4,9 @@
 set -eu
 
 # Install any missing npm packages
-yarn
+# The `--frozen-lockfile` option is important here; it prevents "optimisations" of the lock file that break future deploys
+# See.. https://github.com/yarnpkg/yarn/issues/4379
+yarn install --frozen-lockfile
 
 # Production build
 yarn --cwd website build


### PR DESCRIPTION
Adding the `--frozen-lockfile` option when deploying. This prevents "optimisations" of the lock file that break future deploys. 

See yarn issue [#4379: yarn install changes yarn.lock file](https://github.com/yarnpkg/yarn/issues/4379).