### PR TITLE
added print colors to the swatches

### DIFF
--- a/website/dynamic-blocks/color-swatch.js
+++ b/website/dynamic-blocks/color-swatch.js
@@ -42,9 +42,53 @@ const Component = ({ colors }) => {
 // Separator
 export const ColorSwatch = {
 	editor: ({ value, onChange }) => {
-		const { COLORS } = useBrand();
+		const { COLORS, BRAND } = useBrand();
+
+		const sillyColors = {
+			WBC: {
+				Violet: '#9f4585',
+				'Energy Slide Dark': '#b6000b',
+				'Energy Slide Mid': '#c30019',
+				'Energy Slide Light': '#dd3a46',
+			},
+			BOM: {
+				'Dark Purple': '#20024e',
+				'Mid Purple': '#685ac0',
+				'Light Purple': '#a094fc',
+			},
+			STG: {
+				Sky: '#3fc3eb',
+				Plum: '#502d79',
+				Amber: '#ff7f29',
+				'St.George Yellow': '#ffcd00',
+				'Access Green': '#048938',
+			},
+			BTFG: {
+				'BT Blue': '#00afd7',
+				'BT Black': '#2c2a29',
+				'BT Steel': '#80a1b6',
+			},
+			BSA: {
+				Deep: '#00204f',
+				Bight: '#00adbd',
+				Gum: '#5cbb3e',
+				Grape: '#a22269',
+				Sky: '#abe2ec',
+				Outback: '#f7921e',
+			},
+			WBG: {
+				Westpac: '#d5002b',
+				WIB: '#9f0029',
+				BankSA: '#002f6c',
+				'St.George': '#78be20',
+				BTFG: '#7998ac',
+				Rams: '#00adef',
+				'Bank of Melbourne': '#1f252c',
+			},
+		};
+
 		const swatches = [];
-		for (const key in COLORS) {
+		for (const key in { ...COLORS, ...sillyColors[BRAND] }) {
 			if (typeof COLORS[key] === 'string') {
 				swatches.push({ value: key, label: key });
 			}

--- a/website/dynamic-blocks/color-swatch.js
+++ b/website/dynamic-blocks/color-swatch.js
@@ -52,13 +52,11 @@ export const ColorSwatch = {
 	editor: ({ value, onChange }) => {
 		const { COLORS, BRAND } = useBrand();
 
-		const swatches = Object.entries({ ...COLORS, ...secondaryColors[BRAND] }).map(
-			([key, value]) => {
-				if (typeof value === 'string') {
-					return { value: value, label: key.charAt(0).toUpperCase() + key.slice(1) };
-				}
-			}
-		);
+		const swatches = Object.entries({ ...COLORS, ...secondaryColors[BRAND] })
+			.filter(([key, value]) => typeof value === 'string')
+			.map(([key, value]) => {
+				return { value: value, label: key.charAt(0).toUpperCase() + key.slice(1) };
+			});
 
 		return (
 			<Select

--- a/website/dynamic-blocks/color-swatch.js
+++ b/website/dynamic-blocks/color-swatch.js
@@ -12,9 +12,20 @@ const Swatch = ({ color, name }) => {
 	const [r, g, b] = chroma(color).rgb();
 	return (
 		<div css={{ margin: SPACING(1) }}>
-			<div css={{ background: color, width: SPACING(40), height: SPACING(15) }}></div>
 			<div
-				css={{ padding: SPACING(1), display: 'flex', flexDirection: 'column', background: 'white' }}
+				css={{
+					background: color,
+					width: SPACING(40),
+					height: SPACING(15),
+				}}
+			/>
+			<div
+				css={{
+					padding: SPACING(1),
+					display: 'flex',
+					flexDirection: 'column',
+					background: 'white',
+				}}
 			>
 				<strong css={{ marginTop: SPACING(2) }}>{name}</strong>
 				<span css={{ marginTop: SPACING(1) }}>{color}</span>
@@ -24,20 +35,15 @@ const Swatch = ({ color, name }) => {
 	);
 };
 
-const Component = ({ colors }) => {
-	const { COLORS } = useBrand();
-	return (
-		<Fragment>
-			<div css={{ display: 'flex', flexWrap: 'wrap' }}>
-				{colors
-					.filter(color => typeof COLORS[color.value] === 'string')
-					.map(color => (
-						<Swatch key={color.value} color={COLORS[color.value]} name={color.label} />
-					))}
-			</div>
-		</Fragment>
-	);
-};
+const Component = ({ colors }) => (
+	<Fragment>
+		<div css={{ display: 'flex', flexWrap: 'wrap' }}>
+			{colors.map(color => (
+				<Swatch key={color.value} color={color.value} name={color.label} />
+			))}
+		</div>
+	</Fragment>
+);
 
 // Separator
 export const ColorSwatch = {
@@ -87,12 +93,11 @@ export const ColorSwatch = {
 			},
 		};
 
-		const swatches = [];
-		for (const key in { ...COLORS, ...sillyColors[BRAND] }) {
-			if (typeof COLORS[key] === 'string') {
-				swatches.push({ value: key, label: key });
+		const swatches = Object.entries({ ...COLORS, ...sillyColors[BRAND] }).map(([key, value]) => {
+			if (typeof value === 'string') {
+				return { value: value, label: key.charAt(0).toUpperCase() + key.slice(1) };
 			}
-		}
+		});
 
 		return (
 			<Select

--- a/website/dynamic-blocks/color-swatch.js
+++ b/website/dynamic-blocks/color-swatch.js
@@ -1,8 +1,10 @@
 /** @jsx jsx */
 import React, { Fragment } from 'react'; // Needed for within Keystone
 import { jsx, useBrand } from '@westpac/core';
-import chroma from 'chroma-js';
 import Select from '@arch-ui/select';
+import chroma from 'chroma-js';
+
+import { secondaryColors } from '../src/secondary-colors.js';
 
 // Recursively render swatches
 const Swatch = ({ color, name }) => {
@@ -50,54 +52,13 @@ export const ColorSwatch = {
 	editor: ({ value, onChange }) => {
 		const { COLORS, BRAND } = useBrand();
 
-		const sillyColors = {
-			WBC: {
-				Violet: '#9f4585',
-				'Energy Slide Dark': '#b6000b',
-				'Energy Slide Mid': '#c30019',
-				'Energy Slide Light': '#dd3a46',
-			},
-			BOM: {
-				'Dark Purple': '#20024e',
-				'Mid Purple': '#685ac0',
-				'Light Purple': '#a094fc',
-			},
-			STG: {
-				Sky: '#3fc3eb',
-				Plum: '#502d79',
-				Amber: '#ff7f29',
-				'St.George Yellow': '#ffcd00',
-				'Access Green': '#048938',
-			},
-			BTFG: {
-				'BT Blue': '#00afd7',
-				'BT Black': '#2c2a29',
-				'BT Steel': '#80a1b6',
-			},
-			BSA: {
-				Deep: '#00204f',
-				Bight: '#00adbd',
-				Gum: '#5cbb3e',
-				Grape: '#a22269',
-				Sky: '#abe2ec',
-				Outback: '#f7921e',
-			},
-			WBG: {
-				Westpac: '#d5002b',
-				WIB: '#9f0029',
-				BankSA: '#002f6c',
-				'St.George': '#78be20',
-				BTFG: '#7998ac',
-				Rams: '#00adef',
-				'Bank of Melbourne': '#1f252c',
-			},
-		};
-
-		const swatches = Object.entries({ ...COLORS, ...sillyColors[BRAND] }).map(([key, value]) => {
-			if (typeof value === 'string') {
-				return { value: value, label: key.charAt(0).toUpperCase() + key.slice(1) };
+		const swatches = Object.entries({ ...COLORS, ...secondaryColors[BRAND] }).map(
+			([key, value]) => {
+				if (typeof value === 'string') {
+					return { value: value, label: key.charAt(0).toUpperCase() + key.slice(1) };
+				}
 			}
-		});
+		);
 
 		return (
 			<Select

--- a/website/src/secondary-colors.js
+++ b/website/src/secondary-colors.js
@@ -1,0 +1,42 @@
+export const secondaryColors = {
+	WBC: {
+		Violet: '#9f4585',
+		'Energy Slide Dark': '#b6000b',
+		'Energy Slide Mid': '#c30019',
+		'Energy Slide Light': '#dd3a46',
+	},
+	BOM: {
+		'Dark Purple': '#20024e',
+		'Mid Purple': '#685ac0',
+		'Light Purple': '#a094fc',
+	},
+	STG: {
+		Sky: '#3fc3eb',
+		Plum: '#502d79',
+		Amber: '#ff7f29',
+		'St.George Yellow': '#ffcd00',
+		'Access Green': '#048938',
+	},
+	BTFG: {
+		'BT Blue': '#00afd7',
+		'BT Black': '#2c2a29',
+		'BT Steel': '#80a1b6',
+	},
+	BSA: {
+		Deep: '#00204f',
+		Bight: '#00adbd',
+		Gum: '#5cbb3e',
+		Grape: '#a22269',
+		Sky: '#abe2ec',
+		Outback: '#f7921e',
+	},
+	WBG: {
+		Westpac: '#d5002b',
+		WIB: '#9f0029',
+		BankSA: '#002f6c',
+		'St.George': '#78be20',
+		BTFG: '#7998ac',
+		Rams: '#00adef',
+		'Bank of Melbourne': '#1f252c',
+	},
+};


### PR DESCRIPTION
I was unable to test this locally as Keystone is broken... but theoretically this should now also show the print colors for the `Secondary Palette`.