### PR TITLE
Add shortcodes to all the things

### DIFF
--- a/website/src/components/pages/single-component/blocks-hub.js
+++ b/website/src/components/pages/single-component/blocks-hub.js
@@ -23,6 +23,18 @@ const ApplyShortCodes = ({ text }) => {
 	});
 };
 
+const DynamicComponentsWithShortCode = ({ data, ...rest }) => {
+	if (data.props) {
+		Object.keys(data.props).forEach(key => {
+			if (typeof data.props[key] === 'string') {
+				data.props[key] = ApplyShortCodes({ text: data.props[key] });
+			}
+		});
+	}
+
+	return <DynamicComponents data={data} {...rest} />;
+};
+
 const slateRenderer = (item, _editorValue) => {
 	return createReactRenderer([
 		// special serialiser for text
@@ -128,7 +140,7 @@ const slateRenderer = (item, _editorValue) => {
 
 				case 'dynamic-components': {
 					return (
-						<DynamicComponents
+						<DynamicComponentsWithShortCode
 							key={path}
 							data={node.data}
 							item={item}

--- a/website/src/pages/design-system/[...page].js
+++ b/website/src/pages/design-system/[...page].js
@@ -17,7 +17,10 @@ const ComponentWrapper = () => {
 	const router = useRouter();
 	const tabIndex = router.query.tab;
 	const path = router.query.page.join('/');
-	if (error) return <Error statusCode={400} />;
+
+	if (error) {
+		return <Error statusCode={500} />;
+	}
 	if (!data) return null;
 	let currentComponent =
 		data.allPages.find(component => {


### PR DESCRIPTION
Adds shortcodes to dynamic blocks. 

How it works: 

It looks at all the props for dynamic blocks and if they are a string it attempts to replace the text with shortcodes before passing to the component.

Not that this effects all string props E.g, the heading tag prop `h2` is a sting. This will never be altered because it's not going to match the shortcode syntax: `[[(.*)]]`. I think this should always be safe but I don't love it.

Caveat #2 this will not work for nested props, say we have a dynamic component with a list of paragraphs in a single prop: 

```
<DyamicComp paragraphs={['para1', 'para 2']} /> 
```
Or complex data in a single prop:
```
<DyamicComp data={{
  heading: 'Why is this not flat?'
  paragraph: "I should be a separate prop"
}} /> 
```
Neither of the above examples will have shortcodes applied.