### PR TITLE
toc links and related info ui

### DIFF
--- a/website/dynamic-blocks/intro-section.js
+++ b/website/dynamic-blocks/intro-section.js
@@ -1,7 +1,8 @@
 /** @jsx jsx */
 
-import { Fragment, useEffect, useState } from 'react'; // Needed for within Keystone
+import { Fragment, useEffect, useState, useRef } from 'react'; // Needed for within Keystone
 import { jsx, useBrand, useMediaQuery } from '@westpac/core';
+import { useRouter } from 'next/router';
 import { Heading } from '@westpac/heading';
 import { Body } from '@westpac/body';
 import { List, Item } from '@westpac/list';
@@ -47,11 +48,7 @@ const TableLink = ({ headingId, headingText, ...rest }) => {
 
 const parseHeadings = content =>
 	content.nodes
-		.filter(
-			item =>
-				item.data.component &&
-				(item.data.component === 'Heading' || item.data.component === 'VisionFilters')
-		)
+		.filter(item => item.data.component)
 		.filter(item => item.data.props && item.data.props.addTableContent)
 		.map((item, i) => {
 			const { props } = item.data;
@@ -67,9 +64,19 @@ const parseHeadings = content =>
 // Intro section
 const TableOfContents = ({ content }) => {
 	const toc = parseHeadings(content);
+
 	const { COLORS, SPACING } = useBrand();
+	const [relatedContent, setRelatedContent] = useState(false);
+	const introRef = useRef();
+	useEffect(() => {
+		if (introRef) {
+			const design = introRef.current.closest('#design-tab');
+			setRelatedContent(!!design);
+		}
+	}, [introRef]);
+
 	return (
-		<div>
+		<div ref={introRef}>
 			<Heading tag="h2" size={6} style={{ fontWeight: '500' }}>
 				{'Page content'}
 			</Heading>
@@ -78,7 +85,7 @@ const TableOfContents = ({ content }) => {
 				css={{ border: 'none', borderTop: `solid 1px ${COLORS.border}`, margin: `${SPACING(2)} 0` }}
 			/>
 
-			{toc.length ? (
+			{((toc && toc.length) || (currentTab === 'design' && relatedContent)) && (
 				<nav>
 					<List
 						type="icon"
@@ -93,10 +100,17 @@ const TableOfContents = ({ content }) => {
 							},
 						}}
 					>
-						{toc}
+						{toc && toc.length && toc}
+						{relatedContent && (
+							<TableLink
+								key={`related-information`}
+								headingId={'related-information'}
+								headingText={'Related information'}
+							/>
+						)}
 					</List>
 				</nav>
-			) : null}
+			)}
 		</div>
 	);
 };

--- a/website/dynamic-blocks/props-table.js
+++ b/website/dynamic-blocks/props-table.js
@@ -6,6 +6,8 @@ import { Heading } from '@westpac/heading';
 import PropTypes from '../../GEL.json';
 import { Container, Grid, Cell } from '@westpac/grid';
 import { blocksContainerStyle, blocksGridStyle } from '../src/components/_utils';
+import { FieldContainer } from '@arch-ui/fields';
+import { CheckboxPrimitive } from '@arch-ui/controls';
 
 /**
  * A small helper component for inline code blocks
@@ -155,7 +157,7 @@ function PTable({ data, caption }) {
 	);
 }
 
-const Component = ({ item }) => {
+const Component = ({ item, addTableContent }) => {
 	const mq = useMediaQuery();
 	const { SPACING } = useBrand();
 	const tableData = Object.keys(PropTypes.components[item.packageName])
@@ -181,7 +183,13 @@ const Component = ({ item }) => {
 				columns={12}
 			>
 				<Cell width={12}>
-					<Heading tag="h2" size={5}>
+					<Heading
+						tag="h2"
+						size={5}
+						id="props"
+						tabIndex="-1"
+						{...(addTableContent && { 'data-toc': true })}
+					>
 						Props
 					</Heading>
 				</Cell>
@@ -210,5 +218,32 @@ const Component = ({ item }) => {
 
 // Separator
 export const PropsTable = {
+	editor: ({ value, onChange }) => {
+		const currentValue = {
+			addTableContent: false,
+			heading: 'Props',
+			...(value || {}),
+		};
+
+		const update = changes =>
+			onChange({
+				...currentValue,
+				...changes,
+			});
+		return (
+			<Fragment>
+				<FieldContainer>
+					<label css={{ display: 'flex', margin: '10px 20px 0 0' }}>
+						<CheckboxPrimitive
+							checked={currentValue.addTableContent}
+							tabIndex="0"
+							onChange={({ target }) => update({ addTableContent: target.checked })}
+						/>
+						<span>Include Props Table in table of contents?</span>
+					</label>
+				</FieldContainer>
+			</Fragment>
+		);
+	},
 	component: Component,
 };

--- a/website/dynamic-blocks/screen-reader-demo.js
+++ b/website/dynamic-blocks/screen-reader-demo.js
@@ -10,13 +10,18 @@ import { blocksGridStyle, blocksContainerStyle } from '../src/components/_utils'
 
 export const ScreenReaderText = {
 	editor: ({ value, onChange }) => {
-		const [text, setText] = useState(value.text);
+		const currentValue = {
+			text: value.text,
+			addTableContent: true,
+			heading: 'Screen readers',
+			...(value || {}),
+		};
 
-		useEffect(() => {
+		const update = changes =>
 			onChange({
-				text,
+				...currentValue,
+				...changes,
 			});
-		}, [text]);
 
 		return (
 			<Fragment>
@@ -27,17 +32,15 @@ export const ScreenReaderText = {
 							css={inputStyles}
 							type="text"
 							id="a11y-text"
-							value={text}
-							onChange={async e => {
-								setText(e.target.value);
-							}}
+							value={currentValue.text}
+							onChange={e => update({ text: e.target.value })}
 						/>
 					</FieldInput>
 				</FieldContainer>
 			</Fragment>
 		);
 	},
-	component: ({ text }) => {
+	component: ({ text, addTableContent }) => {
 		const { SPACING, COLORS } = useBrand();
 		const mq = useMediaQuery();
 		return (
@@ -50,7 +53,13 @@ export const ScreenReaderText = {
 					columns={12}
 				>
 					<Cell width={[12, 12, 12, 10, 10]} left={[1, 1, 1, 2, 2]}>
-						<Heading tag="h2" size={5}>
+						<Heading
+							tag="h2"
+							size={5}
+							id="screen-readers"
+							tabIndex="-1"
+							{...(addTableContent && { 'data-toc': true })}
+						>
 							Screen readers
 						</Heading>
 					</Cell>

--- a/website/dynamic-blocks/vision-filters.js
+++ b/website/dynamic-blocks/vision-filters.js
@@ -1,6 +1,6 @@
 /** @jsx jsx */
 import React, { Suspense, Fragment } from 'react';
-import { jsx } from '@westpac/core';
+import { jsx, useBrand } from '@westpac/core';
 import { Body } from '@westpac/body';
 import { Heading } from '@westpac/heading';
 import { useRouter } from 'next/router';
@@ -216,6 +216,7 @@ export const VisionFilters = {
 		const loadCodeBlock = codeExamples[codeExample];
 		const router = useRouter();
 		const href = '/accessibility';
+		const { SPACING } = useBrand();
 
 		const handleClick = e => {
 			e.preventDefault();
@@ -245,7 +246,7 @@ export const VisionFilters = {
 							{heading}
 						</Heading>
 						<Body>
-							<p>
+							<p css={{ margin: `${SPACING(4)} 0 !important` }}>
 								{subText} Read more about these vision impairments on our{' '}
 								<a href={href} onClick={handleClick}>
 									Accessibility

--- a/website/src/components/_utils.js
+++ b/website/src/components/_utils.js
@@ -56,8 +56,14 @@ export const RelatedInformation = ({ item }) => {
 	const { SPACING } = useBrand();
 	const { relatedPages, relatedInfo } = item;
 	const mq = useMediaQuery();
-	if (!relatedPages && !relatedInfo) return null;
+	const hasRelatedPages = relatedPages && relatedPages.length !== 0;
 
+	function checkNode(node) {
+		return node.text || (node.nodes && node.nodes.some(checkNode));
+	}
+	const hasRelatedInfo = checkNode(JSON.parse(relatedInfo.document));
+
+	if (!hasRelatedPages && !hasRelatedInfo) return null;
 	return (
 		<div
 			css={{
@@ -90,9 +96,15 @@ export const RelatedInformation = ({ item }) => {
 						marginTop: [SPACING(6), SPACING(10), SPACING(10)],
 					})}
 				>
-					{relatedPages && (
+					{hasRelatedPages && (
 						<Cell
-							width={[12, 12, relatedInfo ? 4 : 10, relatedInfo ? 4 : 10, relatedInfo ? 4 : 10]}
+							width={[
+								12,
+								12,
+								hasRelatedInfo ? 4 : 10,
+								hasRelatedInfo ? 4 : 10,
+								hasRelatedInfo ? 4 : 10,
+							]}
 							left={[1, 1, 2, 2, 2]}
 						>
 							<IconTitle icon={CubeIcon}>Components</IconTitle>
@@ -107,10 +119,22 @@ export const RelatedInformation = ({ item }) => {
 							</ul>
 						</Cell>
 					)}
-					{relatedInfo && (
+					{hasRelatedInfo && (
 						<Cell
-							width={[12, 12, relatedPages ? 5 : 10, relatedPages ? 5 : 10, relatedPages ? 5 : 10]}
-							left={[1, 1, relatedPages ? 7 : 2, relatedPages ? 7 : 2, relatedPages ? 7 : 2]}
+							width={[
+								12,
+								12,
+								hasRelatedPages ? 5 : 10,
+								hasRelatedPages ? 5 : 10,
+								hasRelatedPages ? 5 : 10,
+							]}
+							left={[
+								1,
+								1,
+								hasRelatedPages ? 7 : 2,
+								hasRelatedPages ? 7 : 2,
+								hasRelatedPages ? 7 : 2,
+							]}
 						>
 							<IconTitle icon={GenericFileIcon}>Articles</IconTitle>
 							<TextOnlySlateContent

--- a/website/src/components/_utils.js
+++ b/website/src/components/_utils.js
@@ -70,7 +70,14 @@ export const RelatedInformation = ({ item }) => {
 			<Container css={blocksContainerStyle}>
 				<Grid css={blocksGridStyle} columns={12}>
 					<Cell width={[12, 12, 12, 10, 10]} left={[1, 1, 1, 2, 2]}>
-						<Heading tag="h2" size={5}>
+						<Heading
+							tag="h2"
+							size={5}
+							addtableContent
+							{...{ 'data-toc': true }}
+							id="related-information"
+							tabIndex="-1"
+						>
 							Related information
 						</Heading>
 					</Cell>
@@ -80,7 +87,7 @@ export const RelatedInformation = ({ item }) => {
 					columns={12}
 					css={mq({
 						...blocksGridStyle,
-						marginTop: ['1.875rem', '1.875rem', '5.625rem'],
+						marginTop: [SPACING(6), SPACING(10), SPACING(10)],
 					})}
 				>
 					{relatedPages && (
@@ -89,7 +96,7 @@ export const RelatedInformation = ({ item }) => {
 							left={[1, 1, 2, 2, 2]}
 						>
 							<IconTitle icon={CubeIcon}>Components</IconTitle>
-							<ul css={{ marginBottom: SPACING(4), padding: 0 }}>
+							<ul css={{ margin: 0, marginBottom: SPACING(3), padding: 0 }}>
 								{relatedPages.map(d => {
 									return (
 										<ComponentLink key={d.id} link={getURL(d)}>
@@ -109,7 +116,10 @@ export const RelatedInformation = ({ item }) => {
 							<TextOnlySlateContent
 								content={relatedInfo}
 								item={item}
-								cssOverrides={{ p: { paddingLeft: 0 } }}
+								cssOverrides={{
+									p: { fontSize: '14px' },
+									div: { marginTop: SPACING(3) },
+								}}
 							/>
 						</Cell>
 					)}
@@ -126,7 +136,6 @@ const ComponentLink = ({ children, link }) => {
 		<li
 			css={{
 				listStyle: 'none',
-				padding: `${SPACING(3)} 0`,
 				borderBottom: `solid 1px ${COLORS.border}`,
 			}}
 		>
@@ -137,9 +146,16 @@ const ComponentLink = ({ children, link }) => {
 						display: 'flex',
 						justifyContent: 'space-between',
 						alignItems: 'center',
+						fontSize: '14px',
 					}}
 				>
-					<span>{children}</span>
+					<span
+						css={{
+							margin: `${SPACING(3)} 0`,
+						}}
+					>
+						{children}
+					</span>
 					<ArrowRightIcon color={COLORS.primary} />
 				</a>
 			</Link>
@@ -159,10 +175,10 @@ const IconTitle = ({ icon: Icon, children }) => {
 				borderBottom: `solid 1px ${COLORS.neutral}`,
 			}}
 		>
-			<Heading tag="h3" size={6}>
+			<Heading tag="h3" size={7} css={{ fontWeight: 500 }}>
 				{children}
 			</Heading>
-			<Icon size="small" />
+			<Icon size="medium" />
 		</div>
 	);
 };

--- a/website/src/components/pages/single-component/blocks-hub.js
+++ b/website/src/components/pages/single-component/blocks-hub.js
@@ -203,11 +203,15 @@ const textOnlySlateRenderer = _editorValue => {
 		// special serialiser for text
 		({ node, path }) => {
 			if (node.object === 'text') {
-				return node.text.split('\n').reduce((array, text, i) => {
+				if (!node.text) {
+					return [<br />];
+				}
+				const x = node.text.split('\n').reduce((array, text, i) => {
 					if (i !== 0) array.push(<br key={`${path}_${i}`} />);
 					array.push(<ApplyShortCodes key={`sc-${path}_${i}`} text={text} />);
 					return array;
 				}, []);
+				return x;
 			}
 		},
 		// serialiser for links
@@ -261,7 +265,11 @@ const textOnlySlateRenderer = _editorValue => {
 
 			switch (node.type) {
 				case 'paragraph':
-					return <p css={textStyle}>{serializeChildren(node.nodes)}</p>;
+					return (
+						<p key={path} css={{ ...textStyle, margin: '0 !important' }}>
+							{serializeChildren(node.nodes)}
+						</p>
+					);
 				default: {
 					console.error(`Unexpected block '${node.type}' at ${path}`);
 				}

--- a/website/src/components/pages/single-component/design-tab.js
+++ b/website/src/components/pages/single-component/design-tab.js
@@ -4,9 +4,9 @@ import { BlocksDocs, RelatedInformation } from '../../_utils';
 
 export const DesignTab = ({ blocks, item }) => {
 	return (
-		<Fragment>
+		<div id="design-tab">
 			<BlocksDocs blocks={blocks} item={item} />
 			<RelatedInformation item={item} />
-		</Fragment>
+		</div>
 	);
 };

--- a/website/src/pages/design-system/[...page].js
+++ b/website/src/pages/design-system/[...page].js
@@ -146,26 +146,6 @@ const Tabs = ({ component, tabName }) => {
 			</div>
 		);
 	}
-	const tabs = [];
-	tabs.push(
-		<Tab key={'design-tab'} overrides={overrides} text="Design">
-			<DesignTab description={component.description} blocks={component.design} item={component} />
-		</Tab>
-	);
-	if (!component.hideAccessibilityTab) {
-		tabs.push(
-			<Tab key={'accessibility-tab'} overrides={overrides} text="Accessibility">
-				<AccessibilityTab blocks={component.accessibility} item={component} />
-			</Tab>
-		);
-	}
-	if (!component.hideCodeTab) {
-		tabs.push(
-			<Tab key={'code-tab'} overrides={overrides} text="Code">
-				<CodeTab blocks={component.code} item={component} />
-			</Tab>
-		);
-	}
 
 	return (
 		<Tabcordion
@@ -174,7 +154,19 @@ const Tabs = ({ component, tabName }) => {
 			onOpen={onOpen}
 			overrides={tabOverrides}
 		>
-			{tabs}
+			<Tab key={'design-tab'} overrides={overrides} text="Design">
+				<DesignTab description={component.description} blocks={component.design} item={component} />
+			</Tab>
+			{!component.hideAccessibilityTab && (
+				<Tab key={'accessibility-tab'} overrides={overrides} text="Accessibility">
+					<AccessibilityTab blocks={component.accessibility} item={component} />
+				</Tab>
+			)}
+			{!component.hideCodeTab && (
+				<Tab key={'code-tab'} overrides={overrides} text="Code">
+					<CodeTab blocks={component.code} item={component} />
+				</Tab>
+			)}
 		</Tabcordion>
 	);
 };


### PR DESCRIPTION
- Requested UI changes to the related content
- Change textOnlySlateRenderer to only use "enter" key for any spacing as per request. No additional margin is required for text outside the blocks.
- Changes to Screen reader UI and addition of editor option to add to TOC
- Props table option to add to TOC
- Related content logic to add to TOC (only if on design tab)