### PR TITLE
WIP: Restricting the next build process to a single thread

### DIFF
--- a/website/src/next.config.js
+++ b/website/src/next.config.js
@@ -22,4 +22,12 @@ const config = {
 		APOLLO_CLIENT_GRAPHQL_URI: process.env.APOLLO_CLIENT_GRAPHQL_URI,
 	},
 };
+
+// Disable parallel building in production
+// Related: https://github.com/zeit/next.js/pull/9199, https://thinkmill.slack.com/archives/CCRK7QEQK/p1588126588313500
+if (process.env.NODE_ENV === 'production') {
+	console.log('Disabling parallel next build in production');
+	config.experimental = { workerThreads: false, cpus: 1 };
+}
+
 module.exports = withPreconstruct(config);


### PR DESCRIPTION
This fixes problems we've seen in the live env where the low mem of that env causes the build to fail:

```
$ cross-env NODE_ENV=production keystone build
- Initialising Keystone CLI
ℹ Command: keystone build
-  
✔ Validated project entry file ./index.js
- Initialising Keystone instance
Loading env vars from /srv/pm2-apps/gel3-website/config.env
Browserslist: caniuse-lite is outdated. Please run next command `yarn upgrade`
✔ Initialised Keystone instance
- Exporting Keystone build to ./dist
Creating an optimized production build...
Attention: Next.js now collects completely anonymous telemetry regarding usage.
This information is used to shape Next.js' roadmap and prioritize features.
You can learn more, including how to opt-out if you'd not like to participate in this anonymous program, by visiting the following URL:
https://nextjs.org/telemetry
> Using external babel configuration
> Location: "/srv/pm2-apps/gel3-website/source/website/src/babel.config.js"
Compiled successfully.
Automatically optimizing pages...
✖ Exporting Keystone build to ./dist
Error: spawn ENOMEM
    at ChildProcess.spawn (internal/child_process.js:407:11)
    at spawn (child_process.js:548:9)
    at Object.fork (child_process.js:116:10)
    at ChildProcessWorker.initialize (/srv/pm2-apps/gel3-website/source/node_modules/next/node_modules/jest-worker/build/workers/ChildProcessWorker.js:137:44)
    at new ChildProcessWorker (/srv/pm2-apps/gel3-website/source/node_modules/next/node_modules/jest-worker/build/workers/ChildProcessWorker.js:127:10)
    at WorkerPool.createWorker (/srv/pm2-apps/gel3-website/source/node_modules/next/node_modules/jest-worker/build/WorkerPool.js:44:12)
    at new BaseWorkerPool (/srv/pm2-apps/gel3-website/source/node_modules/next/node_modules/jest-worker/build/base/BaseWorkerPool.js:82:27)
    at new WorkerPool (/srv/pm2-apps/gel3-website/source/node_modules/next/node_modules/jest-worker/build/WorkerPool.js:30:1)
    at new JestWorker (/srv/pm2-apps/gel3-website/source/node_modules/next/node_modules/jest-worker/build/index.js:131:26)
    at build (/srv/pm2-apps/gel3-website/source/node_modules/next/dist/build/index.js:13:2106)
    at async Promise.all (index 2)
    at Object.exec (/srv/pm2-apps/gel3-website/source/node_modules/@keystonejs/keystone/bin/commands/build.js:42:7) {
  errno: 'ENOMEM',
  code: 'ENOMEM',
  syscall: 'spawn'
}
error Command failed with exit code 1.
```

Ideally we wouldn't be building in the deploy environment but our devops is pretty restricted for this project. We're also planning to increase the spec of the live env.

See Slack for [context](https://thinkmill.slack.com/archives/CCRK7QEQK/p1588126588313500).