### PR TITLE
Make spacing more consistent across blocks

### DIFF
--- a/website/dynamic-blocks/heading.js
+++ b/website/dynamic-blocks/heading.js
@@ -7,15 +7,6 @@ import Select from '@arch-ui/select';
 import { FieldContainer, FieldLabel, FieldInput } from '@arch-ui/fields';
 import { inputStyles } from '@arch-ui/input';
 
-const Component = ({ text, level }) => {
-	return (
-		<WestpacHeading tag={level} size={6}>
-			{text}
-		</WestpacHeading>
-	);
-};
-
-// Separator
 export const Heading = {
 	editor: ({ value, onChange }) => {
 		const [level, setLevel] = useState(value.level);
@@ -63,5 +54,11 @@ export const Heading = {
 		);
 	},
 
-	component: Component,
+	component: ({ text, level }) => {
+		return (
+			<WestpacHeading tag={level} size={6}>
+				{text}
+			</WestpacHeading>
+		);
+	},
 };

--- a/website/dynamic-blocks/headings.js
+++ b/website/dynamic-blocks/headings.js
@@ -11,43 +11,6 @@ import { CheckboxPrimitive } from '@arch-ui/controls';
 import { Input } from '@arch-ui/input';
 import { blocksGridStyle, blocksContainerStyle } from '../src/components/_utils';
 
-const Component = ({ heading, size, level, addTableContent, indent = true, subText, text }) => {
-	const id = heading.replace(/ /g, '-').toLowerCase();
-	const indentWidth = indent ? [12, 12, 12, 10, 10] : 12;
-	const indentLeft = indent ? [1, 1, 1, 2, 2] : 0;
-
-	return (
-		<Container css={blocksContainerStyle}>
-			<Grid columns={12} css={blocksGridStyle}>
-				<Cell width={indentWidth} left={indentLeft}>
-					<WestpacHeading
-						id={id}
-						tabIndex="-1"
-						tag={level}
-						size={size}
-						{...(addTableContent && { 'data-toc': true })}
-						overrides={{
-							Heading: {
-								styles: styles => ({
-									...styles,
-									scrollMarginTop: '75px',
-								}),
-							},
-						}}
-					>
-						{heading}
-					</WestpacHeading>
-					{subText && text && (
-						<Body>
-							<p css={{ lineHeight: 2 }}>{text}</p>
-						</Body>
-					)}
-				</Cell>
-			</Grid>
-		</Container>
-	);
-};
-
 export const Heading = {
 	editor: ({ value, onChange }) => {
 		const currentValue = {
@@ -165,5 +128,40 @@ export const Heading = {
 		);
 	},
 
-	component: Component,
+	component: ({ heading, size, level, addTableContent, indent = true, subText, text }) => {
+		const id = heading.replace(/ /g, '-').toLowerCase();
+		const indentWidth = indent ? [12, 12, 12, 10, 10] : 12;
+		const indentLeft = indent ? [1, 1, 1, 2, 2] : 0;
+
+		return (
+			<Container css={blocksContainerStyle}>
+				<Grid columns={12} css={blocksGridStyle}>
+					<Cell width={indentWidth} left={indentLeft}>
+						<WestpacHeading
+							id={id}
+							tabIndex="-1"
+							tag={level}
+							size={size}
+							{...(addTableContent && { 'data-toc': true })}
+							overrides={{
+								Heading: {
+									styles: styles => ({
+										...styles,
+										scrollMarginTop: '75px',
+									}),
+								},
+							}}
+						>
+							{heading}
+						</WestpacHeading>
+						{subText && text && (
+							<Body>
+								<p css={{ lineHeight: 2 }}>{text}</p>
+							</Body>
+						)}
+					</Cell>
+				</Grid>
+			</Container>
+		);
+	},
 };

--- a/website/dynamic-blocks/image.js
+++ b/website/dynamic-blocks/image.js
@@ -91,12 +91,10 @@ export const Image = {
 
 		const figureStyles = {
 			margin: 0,
-			marginBottom: SPACING(2),
 		};
 
 		const imageStyles = {
 			maxWidth: '100%',
-			marginBottom: SPACING(2),
 		};
 
 		const captionStyle = {

--- a/website/dynamic-blocks/intro-section.js
+++ b/website/dynamic-blocks/intro-section.js
@@ -176,10 +176,10 @@ const PackageInfoTable = ({ item }) => {
 };
 
 const Component = ({ description, showTableOfContents, showPackageInfo, item, _editorValue }) => {
-	const { PACKS, COLORS } = useBrand();
+	const { PACKS, COLORS, SPACING } = useBrand();
 	const mq = useMediaQuery();
 	return (
-		<Fragment>
+		<div css={{ marginBottom: SPACING(5) }}>
 			<Container css={blocksContainerStyle}>
 				<Grid
 					css={mq({
@@ -219,7 +219,7 @@ const Component = ({ description, showTableOfContents, showPackageInfo, item, _e
 					margin: 0,
 				}}
 			/>
-		</Fragment>
+		</div>
 	);
 };
 

--- a/website/dynamic-blocks/props-table.js
+++ b/website/dynamic-blocks/props-table.js
@@ -239,8 +239,8 @@ const Component = ({ item, addTableContent }) => {
 					...blocksContainerStyle,
 					backgroundColor: '#fff',
 					paddingBottom: SPACING(5),
-					marginTop: '0 !important',
-					marginBottom: '-20px !important',
+					marginTop: '0',
+					marginBottom: '-20px',
 				}}
 			>
 				<Grid

--- a/website/dynamic-blocks/props-table.js
+++ b/website/dynamic-blocks/props-table.js
@@ -236,9 +236,11 @@ const Component = ({ item, addTableContent }) => {
 			<SeparatorComponent />
 			<Container
 				css={{
-					backgroundColor: '#fff',
 					...blocksContainerStyle,
+					backgroundColor: '#fff',
 					paddingBottom: SPACING(5),
+					marginTop: '0 !important',
+					marginBottom: '-20px !important',
 				}}
 			>
 				<Grid

--- a/website/dynamic-blocks/screen-reader-demo.js
+++ b/website/dynamic-blocks/screen-reader-demo.js
@@ -45,13 +45,7 @@ export const ScreenReaderText = {
 		const mq = useMediaQuery();
 		return (
 			<Container css={blocksContainerStyle}>
-				<Grid
-					css={mq({
-						...blocksGridStyle,
-						marginTop: [SPACING(6), SPACING(6), SPACING(10)],
-					})}
-					columns={12}
-				>
+				<Grid css={blocksGridStyle} columns={12}>
 					<Cell width={[12, 12, 12, 10, 10]} left={[1, 1, 1, 2, 2]}>
 						<Heading
 							tag="h2"

--- a/website/dynamic-blocks/separator.js
+++ b/website/dynamic-blocks/separator.js
@@ -6,7 +6,7 @@ const SeparatorComponent = () => {
 	const { COLORS, SPACING } = useBrand();
 
 	return (
-		<div css={{ marginTop: `${SPACING(4)} !important`, marginBottom: `${SPACING(7)} !important` }}>
+		<div css={{ marginTop: `${SPACING(2)}`, marginBottom: `${SPACING(4)}` }}>
 			<button
 				css={{
 					display: 'block',

--- a/website/src/components/_utils.js
+++ b/website/src/components/_utils.js
@@ -113,7 +113,7 @@ export const RelatedInformation = ({ item }) => {
 			<div
 				css={{
 					background: 'white',
-					paddingTop: SPACING(8),
+					paddingTop: SPACING(5),
 					paddingBottom: SPACING(12),
 					marginBottom: SPACING(3),
 				}}
@@ -277,6 +277,9 @@ export const blocksGridStyle = {
 	width: '100%',
 };
 export const blocksContainerStyle = {
-	margin: 0,
+	margin: '30px 0',
 	maxWidth: 'unset',
+	'@media (max-width: 768px)': {
+		margin: '18px 0',
+	},
 };

--- a/website/src/components/pages/single-component/blocks-hub.js
+++ b/website/src/components/pages/single-component/blocks-hub.js
@@ -102,7 +102,7 @@ const slateRenderer = (item, _editorValue) => {
 			switch (node.type) {
 				case 'paragraph':
 					return (
-						<Container css={blocksContainerStyle}>
+						<Container css={{ ...blocksContainerStyle, margin: 0 }}>
 							<Grid columns={12} key={path} css={blocksGridStyle}>
 								<Cell width={[12, 10, 8, 8]} left={[1, 2, 3, 3]}>
 									<Body>
@@ -127,7 +127,7 @@ const slateRenderer = (item, _editorValue) => {
 
 				case 'unordered-list':
 					return (
-						<Container css={blocksContainerStyle}>
+						<Container css={{ ...blocksContainerStyle, margin: 0 }}>
 							<Grid columns={12} key={path} css={blocksGridStyle}>
 								<Cell width={[12, 10, 8, 8]} left={[1, 2, 3, 3]}>
 									<List
@@ -148,7 +148,7 @@ const slateRenderer = (item, _editorValue) => {
 
 				case 'ordered-list':
 					return (
-						<Container css={blocksContainerStyle}>
+						<Container css={{ ...blocksContainerStyle, margin: 0 }}>
 							<Grid columns={12} key={path} css={blocksGridStyle}>
 								<Cell width={[12, 10, 8, 8]} left={[1, 2, 3, 3]}>
 									<List css={textStyle} type="ordered">
@@ -189,7 +189,6 @@ export const SlateContent = ({ content, item, cssOverrides, ...props }) => {
 			css={{
 				display: 'flex',
 				flexDirection: 'column',
-				'> *': { marginBottom: '20px' },
 				...cssOverrides,
 			}}
 		>
@@ -286,7 +285,6 @@ export const TextOnlySlateContent = ({ content, cssOverrides, ...props }) => {
 			css={{
 				display: 'flex',
 				flexDirection: 'column',
-				'> *': { marginBottom: '20px' },
 				...cssOverrides,
 			}}
 		>


### PR DESCRIPTION
- adds margins to the container that wraps all blocks
- removes global margin
- text is exception to the extra margins
- removes unnecessary !importants
- moves a couple of components back into the main export as they are short and extracting them doesn't improve legibility.