### PR TITLE
Adding cookie secret config to Keystone init

### DIFF
--- a/website/example.env
+++ b/website/example.env
@@ -13,3 +13,7 @@ APOLLO_CLIENT_GRAPHQL_URI="http://localhost:3000/admin/api"
 
 # Postgres DB
 DATABASE_URL="postgres://localhost/gel3_website_dev"
+
+# Set this to something secure, even in dev
+# eg. `openssl rand -base64 18`
+COOKIE_SECRET="change-me"

--- a/website/index.js
+++ b/website/index.js
@@ -23,6 +23,10 @@ const keystone = new Keystone({
 			connection: process.env.DATABASE_URL,
 		},
 	}),
+	// Add COOKIE_SECRET to your .env or sessions will be reset when the app restarts
+	cookieSecret:
+		process.env.COOKIE_SECRET ||
+		[...Array(30)].map(i => ((Math.random() * 36) | 0).toString(36)).join(''),
 });
 
 const options = resolveComponents();


### PR DESCRIPTION
This needs to be set to make the app production ready.

I've added config to the live and staging servers setting this value so all we need to do is roll this change out. All sessions will be reset (once) when this change is deployed (but after that will be stable).

Developers will need to add a `COOKIE_SECRET` value to their `.env` files, as per the notes in `website/example.env`.