### PR TITLE
Refactor grid

### DIFF
--- a/components/core/src/GEL.js
+++ b/components/core/src/GEL.js
@@ -20,5 +20,5 @@ export const GEL = ({ brand, noReset, children, ...props }) => {
 
 GEL.propTypes = {
 	noReset: PropTypes.bool,
-	brand: PropTypes.func,
+	brand: PropTypes.oneOfType([PropTypes.object, PropTypes.func]),
 };

--- a/components/grid/src/Cell.js
+++ b/components/grid/src/Cell.js
@@ -72,7 +72,11 @@ Cell.propTypes = {
 	/**
 	 * The `grid-column-start` CSS property.
 	 */
-	left: PropTypes.oneOfType([PropTypes.number, PropTypes.arrayOf(PropTypes.number)]),
+	left: PropTypes.oneOfType([
+		PropTypes.number,
+		PropTypes.string,
+		PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.number, PropTypes.string])),
+	]),
 
 	/**
 	 * The `grid-row-start` CSS property.

--- a/components/grid/src/Grid.js
+++ b/components/grid/src/Grid.js
@@ -164,7 +164,11 @@ Grid.propTypes = {
 	/**
 	 * The `row-gap` CSS property.
 	 */
-	rowGap: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+	rowGap: PropTypes.oneOfType([
+		PropTypes.number,
+		PropTypes.string,
+		PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.number, PropTypes.string])),
+	]),
 
 	/**
 	 * The `grid-template-rows` CSS property. When a number is passed it is a

--- a/components/grid/src/overrides/grid.js
+++ b/components/grid/src/overrides/grid.js
@@ -28,7 +28,7 @@ const gridStyles = (
 	const formatAreas = (areas) => areas.map((area) => `"${area}"`).join(' ');
 
 	return mq({
-		alignContent: alignContent,
+		alignContent,
 		columnGap,
 		display: 'grid',
 		gridAutoFlow: flow,


### PR DESCRIPTION
- Updates Grid's `rowGap` propType declaration (should be able to take string value - rowGap's default CSS value is 'normal')

- Updates Cell's `left` propType declaration (should be able to take string value – grid-column-start's default value is 'auto')

Also includes a fix for GEL `brand` prop's incorrect propType declaration