### PR TITLE
fixed icon state and showed how to override an icon entirely

### DIFF
--- a/.changeset/short-elephants-wash.md
+++ b/.changeset/short-elephants-wash.md
@@ -1,0 +1,5 @@
+---
+'@westpac/icon': patch
+---
+
+Fixed state so that icon now is passed into it

--- a/components/icon/examples/60-overrides.js
+++ b/components/icon/examples/60-overrides.js
@@ -3,6 +3,7 @@
 import { GEL, jsx } from '@westpac/core';
 import {
 	AddIcon,
+	BankIcon,
 	CalendarIcon,
 	DeleteIcon,
 	GridIcon,
@@ -15,13 +16,26 @@ import { Fragment } from 'react';
 
 import { Intopia } from '../../../helpers/example/components/Intopia.js';
 
-const Wrapper = ({ children, icon, color, size, assistiveText, ...rest }) => (
+const Wrapper = ({ children, state: { icon }, ...rest }) => (
 	<Fragment>
 		<div {...rest}>{children}</div>
 		<div css={{ marginBottom: '1rem' }}>
 			name: <span css={{ fontWeight: 900 }}>{icon}</span>
 		</div>
 	</Fragment>
+);
+
+const Svg = ({ children, state: { icon, assistiveText }, ...rest }) => (
+	<svg
+		aria-label={assistiveText}
+		xmlns="http://www.w3.org/2000/svg"
+		viewBox="0 0 24 24"
+		role="img"
+		focusable="false"
+		{...rest}
+	>
+		{icon === 'BankIcon' ? <circle fill="currentColor" cx="12" cy="12" r="12"></circle> : children}
+	</svg>
 );
 
 function Example({ brand }) {
@@ -33,6 +47,9 @@ function Example({ brand }) {
 				outline: '1px solid red',
 			}),
 			component: Wrapper,
+		},
+		Svg: {
+			component: Svg,
 		},
 	};
 
@@ -49,6 +66,9 @@ function Example({ brand }) {
 			<MessageIcon />
 			<StarIcon />
 			<WriteIcon />
+
+			<h2>Overriding the icon itself</h2>
+			<BankIcon />
 
 			<h2>With overrides and component overrides</h2>
 			<AddIcon

--- a/components/icon/src/Icon.js
+++ b/components/icon/src/Icon.js
@@ -34,6 +34,7 @@ export const Icon = ({
 		color,
 		size,
 		assistiveText,
+		icon,
 		overrides: componentOverrides,
 		...rest,
 	};


### PR DESCRIPTION
The icon omited the `icon` name in it's state. Must have been deleted when we moved to nested `state` prop.
I also showed how one may override the entire icon paths if they chose to.