### PR TITLE
Brand updates

### DIFF
--- a/.changeset/friendly-clouds-complain.md
+++ b/.changeset/friendly-clouds-complain.md
@@ -1,0 +1,5 @@
+---
+'@westpac/core': minor
+---
+
+Update font demos

--- a/.changeset/short-elephants-wash.md
+++ b/.changeset/short-elephants-wash.md
@@ -2,4 +2,4 @@
 '@westpac/icon': patch
 ---
 
-Fix state so that icon now is passed into it
+Fix state so that icon is now passed into it

--- a/.changeset/smart-dragons-rescue.md
+++ b/.changeset/smart-dragons-rescue.md
@@ -1,5 +1,0 @@
----
-'@westpac/panel': major
----
-
-Fix heading text colour for STG brand

--- a/.changeset/strange-ads-reply.md
+++ b/.changeset/strange-ads-reply.md
@@ -1,5 +1,0 @@
----
-'@westpac/tabcordion': major
----
-
-Fix lego tab text colour for STG brand

--- a/components/core/demos/design/body-fonts.js
+++ b/components/core/demos/design/body-fonts.js
@@ -2,26 +2,25 @@
 
 import { jsx, useBrand } from '@westpac/core';
 import { Playground } from '../../../../website/src/components/playground/macro';
+import { Body } from '../../../../website/src/components/body';
 
-const Wrapper = (props) => {
+const StyledText = (props) => {
 	const { PACKS } = useBrand();
-	return <div css={{ ...PACKS.typeScale.bodyFont[4] }} {...props} />;
+	return <p css={{ ...PACKS.typeScale.bodyFont[4] }} {...props} />;
 };
-
-const StyledText = (props) => <p css={{ marginTop: 0 }} {...props} />;
 
 export default ({ context, showCode, showDemo }) => {
 	return (
 		<Playground context={context} showCode={showCode} showDemo={showDemo}>
-			<p>Sans serif system font</p>
-			<Wrapper>
+			<Body>
+				<p>Sans serif system font</p>
 				<StyledText>
 					ABCDEFGHIJKLMNOPQRSTUVWXYZ
 					<br />
 					abcdefghijklmnopqrstuvwxyz
 					<br />0 1 2 3 4 5 6 7 8 9
 				</StyledText>
-			</Wrapper>
+			</Body>
 		</Playground>
 	);
 };

--- a/components/core/demos/design/brand-font.js
+++ b/components/core/demos/design/brand-font.js
@@ -16,9 +16,9 @@ export default ({ context, showCode, showDemo }) => {
 	const brandFontMap = {
 		WBC: 'Chronicle Semibold',
 		STG: 'Dragon Bold',
-		BOM: 'Brown Bold',
-		BSA: 'Aller Bold',
-		WBG: 'Times New Roman',
+		BOM: 'Brown',
+		BSA: 'Aller',
+		WBG: 'Montserrat',
 	};
 
 	return (

--- a/components/core/demos/design/brand-font.js
+++ b/components/core/demos/design/brand-font.js
@@ -1,37 +1,51 @@
 /** @jsx jsx */
-
 import { jsx, useBrand } from '@westpac/core';
+import { Fragment } from 'react';
 import { Playground } from '../../../../website/src/components/playground/macro';
+import { Body } from '../../../../website/src/components/body';
 
-const Wrapper = (props) => {
-	const { PACKS } = useBrand();
-	return <div css={{ ...PACKS.typeScale.brandFont[4] }} {...props} />;
+const StyledText = ({ weight, ...rest }) => {
+	const { PACKS, TYPE } = useBrand();
+	return <p css={{ ...PACKS.typeScale.brandFont[4], ...TYPE.bodyFont[weight] }} {...rest} />;
 };
-
-const StyledText = (props) => <p css={{ marginTop: 0 }} {...props} />;
 
 export default ({ context, showCode, showDemo }) => {
 	const { BRAND } = useBrand();
 
 	const brandFontMap = {
-		WBC: 'Chronicle Semibold',
-		STG: 'Dragon Bold',
-		BOM: 'Brown',
-		BSA: 'Aller',
-		WBG: 'Montserrat',
+		WBC: [{ name: 'Chronicle Semibold', weight: 400 }],
+		STG: [{ name: 'Dragon Bold', weight: 400 }],
+		BOM: [
+			{ name: 'Brown Light', weight: 300 },
+			{ name: 'Brown Regular', weight: 400 },
+			{ name: 'Brown Bold', weight: 700 },
+		],
+		BSA: [
+			{ name: 'Aller Light', weight: 300 },
+			{ name: 'Aller Bold', weight: 700 },
+		],
+		WBG: [
+			{ name: 'Montserrat Light', weight: 300 },
+			{ name: 'Montserrat Regular', weight: 400 },
+			{ name: 'Montserrat Bold', weight: 700 },
+		],
 	};
 
 	return (
 		<Playground context={context} showCode={showCode} showDemo={showDemo}>
-			<p>{brandFontMap[BRAND]}</p>
-			<Wrapper>
-				<StyledText>
-					ABCDEFGHIJKLMNOPQRSTUVWXYZ
-					<br />
-					abcdefghijklmnopqrstuvwxyz
-					<br />0 1 2 3 4 5 6 7 8 9
-				</StyledText>
-			</Wrapper>
+			<Body>
+				{brandFontMap[BRAND].map((font, i) => (
+					<Fragment key={i}>
+						<p>{font.name}</p>
+						<StyledText weight={font.weight}>
+							ABCDEFGHIJKLMNOPQRSTUVWXYZ
+							<br />
+							abcdefghijklmnopqrstuvwxyz
+							<br />0 1 2 3 4 5 6 7 8 9
+						</StyledText>
+					</Fragment>
+				))}
+			</Body>
 		</Playground>
 	);
 };

--- a/website/dynamic-blocks/intro-section.js
+++ b/website/dynamic-blocks/intro-section.js
@@ -143,7 +143,7 @@ const PackageInfoTable = ({ item }) => {
 				color: '#2585ca',
 				width: '100%',
 				textAlign: 'left',
-				...PACKS.typeScale.brandFont[10],
+				...PACKS.typeScale.bodyFont[10],
 			})}
 		>
 			<tbody
@@ -182,7 +182,7 @@ const PackageInfoTable = ({ item }) => {
 				</tr>
 				<tr>
 					<th>Requires</th>
-					<td>{item.requires}</td>
+					<td>{item.requires || 'None'}</td>
 				</tr>
 			</tbody>
 		</table>

--- a/website/src/components/_utils.js
+++ b/website/src/components/_utils.js
@@ -72,7 +72,7 @@ export const brandHeaderStyling = {
 	STG: (COLORS) => ({
 		background: COLORS.hero,
 		color: '#fff',
-		antialiasing: null,
+		antialiasing: antialiasingStyling,
 	}),
 	BSA: (COLORS) => ({
 		background: `linear-gradient(to right, ${COLORS.hero} 0%, #00468e 50%, #00adbd 100%)`,

--- a/website/src/components/_utils.js
+++ b/website/src/components/_utils.js
@@ -71,7 +71,7 @@ export const brandHeaderStyling = {
 	}),
 	STG: (COLORS) => ({
 		background: COLORS.hero,
-		color: COLORS.text,
+		color: '#fff',
 		antialiasing: null,
 	}),
 	BSA: (COLORS) => ({

--- a/website/src/components/header/home-page-header.js
+++ b/website/src/components/header/home-page-header.js
@@ -115,7 +115,7 @@ const StickyHeader = () => {
 					})}
 					onClick={() => setIsOpen(!isOpen)}
 				>
-					<HamburgerMenuIcon color={BRAND === 'STG' ? COLORS.text : '#fff'} />
+					<HamburgerMenuIcon color="#fff" />
 				</button>
 				<p
 					css={mq({

--- a/website/src/components/header/page-header.js
+++ b/website/src/components/header/page-header.js
@@ -16,7 +16,7 @@ const MenuButton = () => {
 	const mq = useMediaQuery();
 	const { setIsOpen } = useSidebar();
 
-	const Icon = () => <HamburgerMenuIcon color={BRAND === 'STG' ? COLORS.text : '#fff'} />;
+	const Icon = () => <HamburgerMenuIcon color="#fff" />;
 
 	return (
 		<Button
@@ -144,7 +144,7 @@ const PageHeader = ({ name, version }) => {
 				css={mq({
 					display: 'flex',
 					alignItems: 'flex-end', //align bottom
-					color: BRAND === 'STG' ? COLORS.text : '#fff',
+					color: '#fff',
 				})}
 			>
 				<MenuButton />

--- a/website/src/secondary-colors.js
+++ b/website/src/secondary-colors.js
@@ -15,7 +15,7 @@ export const secondaryColors = {
 		Plum: '#502d79',
 		Amber: '#ff7f29',
 		'St.George Yellow': '#ffcd00',
-		'Access Green': '#048938',
+		'St.George Green': '#78be20',
 	},
 	BTFG: {
 		'BT Blue': '#00afd7',


### PR DESCRIPTION
Updates to the website
- remove custom color mappings etc
- update fonts demos (in `@westpac/core`) - now renders demos for all weights

Hey @jaortiz ... we have relative links to the website in our published packages (demos)
e.g. `import { Playground } from '../../../../website/src/components/playground/macro';`.
Is that kosher?