### PR TITLE
Fix website components

### DIFF
--- a/website/dynamic-blocks/color-swatch.js
+++ b/website/dynamic-blocks/color-swatch.js
@@ -5,7 +5,7 @@ import { jsx, useBrand, useMediaQuery } from '@westpac/core';
 import { Cell } from '@westpac/grid';
 import Select from '@arch-ui/select';
 import chroma from 'chroma-js';
-import { Body } from '@westpac/body';
+import { Body } from '../src/components/body';
 
 import { secondaryColors } from '../src/secondary-colors.js';
 

--- a/website/dynamic-blocks/headings.js
+++ b/website/dynamic-blocks/headings.js
@@ -3,7 +3,7 @@
 import { Fragment } from 'react';
 import { Heading as WestpacHeading } from '@westpac/heading';
 import { jsx, useMediaQuery } from '@westpac/core';
-import { Body } from '@westpac/body';
+import { Body } from '../src/components/body';
 import { Cell } from '@westpac/grid';
 
 import { FieldContainer, FieldLabel, FieldInput } from '@arch-ui/fields';
@@ -193,7 +193,7 @@ export const Heading = {
 					{heading}
 				</WestpacHeading>
 				{subText && text && (
-					<Body css={mq({ p: { margin: ['0 0 18px', null, '0 0 24px'] } })}>
+					<Body>
 						<p>{text}</p>
 					</Body>
 				)}

--- a/website/dynamic-blocks/headings.js
+++ b/website/dynamic-blocks/headings.js
@@ -1,7 +1,7 @@
 /** @jsx jsx */
 
 import { Fragment } from 'react';
-import { Heading as WestpacHeading } from '@westpac/heading';
+import { Heading as GELHeading } from '@westpac/heading';
 import { jsx, useMediaQuery } from '@westpac/core';
 import { Body } from '../src/components/body';
 import { Cell } from '@westpac/grid';
@@ -171,7 +171,7 @@ export const Heading = {
 
 		return (
 			<Cell width={widthMap[indentLevel]} left={indentMap[indentLevel]}>
-				<WestpacHeading
+				<GELHeading
 					id={id}
 					tabIndex="-1"
 					tag={level}
@@ -182,8 +182,8 @@ export const Heading = {
 								merge({}, styles, {
 									...mq({
 										scrollMarginTop: '10.375rem',
-										marginTop: !removeTopMargin && size > 6 && '12px',
-										marginBottom: codeStyles ? ['12px', null, '18px'] : marginMap[size],
+										marginTop: !removeTopMargin && size > 6 && '0.75rem',
+										marginBottom: codeStyles ? ['0.75rem', null, '1.125rem'] : marginMap[size],
 										textTransform: size === 10 && 'uppercase',
 									})[0],
 								}),
@@ -191,7 +191,7 @@ export const Heading = {
 					}}
 				>
 					{heading}
-				</WestpacHeading>
+				</GELHeading>
 				{subText && text && (
 					<Body>
 						<p>{text}</p>

--- a/website/dynamic-blocks/intro-section.js
+++ b/website/dynamic-blocks/intro-section.js
@@ -205,11 +205,10 @@ const Component = ({ description, showTableOfContents, showPackageInfo, item, _e
 								{description && description !== '' ? (
 									<p
 										css={mq({
-											...PACKS.lead,
-											marginTop: 0,
-											marginBottom: 0,
-											lineHeight: 1.4,
-											fontSize: ['1.125rem', '1.125rem', '1.5rem'],
+											margin: 0,
+											fontSize: ['1.125rem', null, '1.5rem'],
+											lineHeight: 1.5,
+											fontWeight: 300,
 										})}
 									>
 										{description}

--- a/website/dynamic-blocks/intro-section.js
+++ b/website/dynamic-blocks/intro-section.js
@@ -5,7 +5,7 @@ import { jsx, Global, useBrand, useMediaQuery } from '@westpac/core';
 import { Cell, Grid, Container } from '@westpac/grid';
 import { List, Item } from '@westpac/list';
 import { Heading } from '@westpac/heading';
-import { Body } from '@westpac/body';
+import { Body } from '../src/components/body';
 
 import { FieldContainer, FieldLabel, FieldInput } from '@arch-ui/fields';
 import { CheckboxPrimitive } from '@arch-ui/controls';

--- a/website/dynamic-blocks/vision-filters.js
+++ b/website/dynamic-blocks/vision-filters.js
@@ -3,7 +3,7 @@ import React, { Suspense, Fragment } from 'react';
 
 import { jsx, useBrand, useMediaQuery } from '@westpac/core';
 import { Heading } from '@westpac/heading';
-import { Body } from '@westpac/body';
+import { Body } from '../src/components/body';
 import { Cell } from '@westpac/grid';
 
 import { FieldContainer, FieldLabel, FieldInput } from '@arch-ui/fields';

--- a/website/field-content/src/views/editor/blocks/blockquote.js
+++ b/website/field-content/src/views/editor/blocks/blockquote.js
@@ -1,7 +1,7 @@
 /** @jsx jsx */
 
 import { jsx } from '@emotion/core';
-import { Body } from '../../../../src/components/body';
+import { Body } from '../../../../../src/components/body';
 
 import { ToolbarButton } from '../toolbar-components';
 import { BlockQuoteIcon } from '../toolbar-icons';

--- a/website/field-content/src/views/editor/blocks/blockquote.js
+++ b/website/field-content/src/views/editor/blocks/blockquote.js
@@ -1,7 +1,7 @@
 /** @jsx jsx */
 
 import { jsx } from '@emotion/core';
-import { Body } from '@westpac/body';
+import { Body } from '../../../../src/components/body';
 
 import { ToolbarButton } from '../toolbar-components';
 import { BlockQuoteIcon } from '../toolbar-icons';

--- a/website/src/brand-overrides.js
+++ b/website/src/brand-overrides.js
@@ -1,67 +1,18 @@
-import merge from 'lodash.merge';
-
 export const brandOverrides = (brand) => {
 	const { PACKS, TYPE } = brand;
 	const overridesWithTokens = { ...brand };
 
-	// Body overrides
+	// Example
+	/* const BodyOverride = (props) => <div {...props}/>;	 
 	overridesWithTokens['@westpac/body'] = {
 		Body: {
+			component: () => BodyOverride,
 			styles: (styles) => ({
 				...styles,
-
-				fontSize: '1rem',
-				lineHeight: 2,
-
-				'h1, h2, h3, h4, h5, h6': {
-					color: 'inherit',
-				},
-				h2: {
-					...PACKS.typeScale.bodyFont[6],
-					fontWeight: TYPE.bodyFont.headingWeight,
-					margin: '0 0 1.125rem',
-				},
-				h3: {
-					...PACKS.typeScale.bodyFont[8],
-					fontWeight: TYPE.bodyFont.headingWeight,
-					margin: '0 0 1.125rem',
-				},
-				p: {
-					margin: '0 0 0.75rem !important',
-				},
 			}),
+			attributes: () => null,
 		},
-	};
-
-	// List overrides
-	const listStyleMap = {
-		bullet: {
-			'::before': {
-				top: '0.75rem',
-			},
-		},
-		link: {
-			'::before': {
-				top: '0.75rem',
-			},
-		},
-		tick: {
-			'::before': {
-				top: '0.625rem',
-			},
-		},
-	};
-	overridesWithTokens['@westpac/list'] = {
-		List: {
-			styles: (styles, { type }) =>
-				merge({}, styles, {
-					'> li': {
-						// Reposition bullets/ticks etc
-						...listStyleMap[type],
-					},
-				}),
-		},
-	};
+	}; */
 
 	return overridesWithTokens;
 };

--- a/website/src/components/body/body.js
+++ b/website/src/components/body/body.js
@@ -1,0 +1,41 @@
+/** @jsx jsx */
+
+import { jsx, useBrand } from '@westpac/core';
+import { Body as GELBody } from '@westpac/body';
+
+export const Body = (props) => {
+	const { PACKS, TYPE, SPACING } = useBrand();
+
+	return (
+		<GELBody
+			overrides={{
+				Body: {
+					styles: (styles) => ({
+						...styles,
+
+						fontSize: '1rem',
+						lineHeight: 2,
+
+						'h1, h2, h3, h4, h5, h6': {
+							color: 'inherit',
+						},
+						h2: {
+							...PACKS.typeScale.bodyFont[6],
+							fontWeight: TYPE.bodyFont.headingWeight,
+							margin: `0 0 ${SPACING(4)}`,
+						},
+						h3: {
+							...PACKS.typeScale.bodyFont[8],
+							fontWeight: TYPE.bodyFont.headingWeight,
+							margin: `0 0 ${SPACING(3)}`,
+						},
+						p: {
+							margin: `0 0 ${SPACING(2)} !important`,
+						},
+					}),
+				},
+			}}
+			{...props}
+		/>
+	);
+};

--- a/website/src/components/body/index.js
+++ b/website/src/components/body/index.js
@@ -1,0 +1,1 @@
+export { Body } from './body';

--- a/website/src/components/brand-picker/brand-picker.js
+++ b/website/src/components/brand-picker/brand-picker.js
@@ -6,7 +6,7 @@ import { useBrandSwitcher } from '../providers/brand-switcher';
 import { useRouter } from 'next/router';
 import { Container, Grid, Cell } from '@westpac/grid';
 import { Section } from '../../components/section';
-import { Body } from '@westpac/body';
+import { Body } from '../body';
 import { BASE_URL } from '../../config.js';
 import { findByDisplayValue } from '@testing-library/react';
 

--- a/website/src/components/header/home-page-header.js
+++ b/website/src/components/header/home-page-header.js
@@ -2,7 +2,7 @@
 import { jsx, useBrand, useMediaQuery } from '@westpac/core';
 import React, { useEffect, useState, useRef, Fragment } from 'react';
 import { HamburgerMenuIcon } from '@westpac/icon';
-import { Body } from '@westpac/body';
+import { Body } from '../body';
 import { Cell, Container, Grid } from '@westpac/grid';
 import { BrandHeading } from '@westpac/heading';
 import HeaderImage from './home-page-header-image';
@@ -264,14 +264,16 @@ const HeroIntro = () => {
 			</Grid>
 			<Grid css={mq({ marginTop: [SPACING(4), SPACING(6)] })}>
 				<Cell width={10} left={2}>
-					<p
-						css={mq({
-							margin: 0,
-							...PACKS.typeScale.bodyFont[8],
-						})}
-					>
-						Assemble enterprise solutions with our components and patterns
-					</p>
+					<Body>
+						<p
+							css={mq({
+								margin: 0,
+								...PACKS.typeScale.bodyFont[8],
+							})}
+						>
+							Assemble enterprise solutions with our components and patterns
+						</p>
+					</Body>
 				</Cell>
 			</Grid>
 			<HeroFeatures />

--- a/website/src/components/list/index.js
+++ b/website/src/components/list/index.js
@@ -1,0 +1,2 @@
+export { List } from './list';
+export { Item } from './item';

--- a/website/src/components/list/item.js
+++ b/website/src/components/list/item.js
@@ -1,0 +1,6 @@
+/** @jsx jsx */
+
+import { jsx } from '@westpac/core';
+import { Item as GELItem } from '@westpac/list';
+
+export const Item = (props) => <GELItem {...props} />;

--- a/website/src/components/list/list.js
+++ b/website/src/components/list/list.js
@@ -1,0 +1,44 @@
+/** @jsx jsx */
+
+import { jsx } from '@westpac/core';
+import { List as GELList } from '@westpac/list';
+import { Body as ListOverride } from '../body';
+import merge from 'lodash.merge';
+
+const listStyleMap = {
+	bullet: {
+		'::before': {
+			top: '0.75rem',
+		},
+	},
+	link: {
+		'::before': {
+			top: '0.75rem',
+		},
+	},
+	tick: {
+		'::before': {
+			top: '0.625rem',
+		},
+	},
+};
+
+export const List = (props) => {
+	return (
+		<GELList
+			overrides={{
+				List: {
+					component: ListOverride,
+					styles: (styles, { type }) =>
+						merge({}, styles, {
+							'> li': {
+								// Reposition bullets/ticks etc
+								...listStyleMap[type],
+							},
+						}),
+				},
+			}}
+			{...props}
+		/>
+	);
+};

--- a/website/src/components/pages/single-component/blocks-hub.js
+++ b/website/src/components/pages/single-component/blocks-hub.js
@@ -3,7 +3,7 @@
 import { jsx, useBrand } from '@westpac/core';
 import { Cell, Grid, Container } from '@westpac/grid';
 import { Heading } from '@westpac/heading';
-import { List, Item } from '@westpac/list';
+import { List, Item } from '../../list';
 import { Body } from '../../body';
 import { Section } from '../../section';
 import dynamic from 'next/dynamic';
@@ -41,6 +41,8 @@ const DynamicComponentsWithShortCode = ({ data, ...rest }) => {
 };
 
 const slateRenderer = (item, _editorValue) => {
+	const { SPACING } = useBrand();
+
 	return createReactRenderer([
 		// special serialiser for text
 		({ node, path }) => {
@@ -123,7 +125,7 @@ const slateRenderer = (item, _editorValue) => {
 				case 'unordered-list':
 					return (
 						<Cell key={path} width={[12, null, 10, 8]} left={[1, null, 2, 3]}>
-							<List type="bullet" css={{ marginBottom: '0.75rem' }}>
+							<List type="bullet" css={{ marginBottom: SPACING(2) }}>
 								{serializeChildren(node.nodes)}
 							</List>
 						</Cell>
@@ -132,7 +134,7 @@ const slateRenderer = (item, _editorValue) => {
 				case 'ordered-list':
 					return (
 						<Cell key={path} width={[12, null, 10, 8]} left={[1, null, 2, 3]}>
-							<List type="ordered" css={{ marginBottom: '0.75rem' }}>
+							<List type="ordered" css={{ marginBottom: SPACING(2) }}>
 								{serializeChildren(node.nodes)}
 							</List>
 						</Cell>

--- a/website/src/components/pages/single-component/blocks-hub.js
+++ b/website/src/components/pages/single-component/blocks-hub.js
@@ -4,8 +4,8 @@ import { jsx, useBrand } from '@westpac/core';
 import { Cell, Grid, Container } from '@westpac/grid';
 import { Heading } from '@westpac/heading';
 import { List, Item } from '@westpac/list';
-import { Body } from '@westpac/body';
 import { Section } from '../../../components/section';
+import { Body } from '../../body';
 import dynamic from 'next/dynamic';
 import React from 'react';
 

--- a/website/src/components/pages/single-component/blocks-hub.js
+++ b/website/src/components/pages/single-component/blocks-hub.js
@@ -4,8 +4,8 @@ import { jsx, useBrand } from '@westpac/core';
 import { Cell, Grid, Container } from '@westpac/grid';
 import { Heading } from '@westpac/heading';
 import { List, Item } from '@westpac/list';
-import { Section } from '../../../components/section';
 import { Body } from '../../body';
+import { Section } from '../../section';
 import dynamic from 'next/dynamic';
 import React from 'react';
 

--- a/website/src/pages/design-system/downloads/index.js
+++ b/website/src/pages/design-system/downloads/index.js
@@ -7,7 +7,7 @@ import { FormCheck, Option } from '@westpac/form-check';
 import { Select } from '@westpac/text-input';
 import { Container, Grid, Cell } from '@westpac/grid';
 import { Button } from '@westpac/button';
-import { Body } from '@westpac/body';
+import { Body } from '../../../components/body';
 
 import PageHeader from '../../../components/header/page-header';
 import { PageContext } from '../../../components/providers/pageContext';

--- a/website/src/pages/design-system/index.js
+++ b/website/src/pages/design-system/index.js
@@ -6,7 +6,7 @@ import { Button } from '@westpac/button';
 import { TextInput } from '@westpac/text-input';
 import HomePageHeader from '../../components/header/home-page-header';
 import { Section } from '../../components/section';
-import { Body } from '@westpac/body';
+import { Body } from '../../components/body';
 import { BlockList, BlockListItem } from '../../components/block-list';
 import { BlockHeading } from '../../components/block-heading';
 import { Footer } from '../../components/layout/footer';


### PR DESCRIPTION
Remove the brand overrides and instead create our own website specific `<Body />` and `<List />` components, which wrap and override the standard GEL Body and List components. 

This approach will mean we won't have issues rending our GEL components in the example Wells for example. 

Basically where our GEL Website component styling veers off standard GEL component styling (e.g. larger Body line-height and font-size), using this approach will mean any components we do want to look like standard wont need overriding back to standard. We only override the parts of the site we need to, not everything site wide.