### PR TITLE
Tidy up destructured props

### DIFF
--- a/components/a11y/src/overrides/skipLink.js
+++ b/components/a11y/src/overrides/skipLink.js
@@ -2,7 +2,7 @@
 
 import { jsx, getLabel } from '@westpac/core';
 
-const SkipLink = ({ state, ...rest }) => <a {...rest} />;
+const SkipLink = ({ state: _, ...rest }) => <a {...rest} />;
 
 const skipLinkStyles = () => ({
 	label: getLabel('skipLink'),

--- a/components/alert/examples/40-overrides.js
+++ b/components/alert/examples/40-overrides.js
@@ -4,7 +4,7 @@ import { GEL, jsx } from '@westpac/core';
 import { TickIcon, InfoIcon, AlertIcon, HouseIcon } from '@westpac/icon';
 import { Alert } from '@westpac/alert';
 
-const CloseBtn = ({ onClose, state, ...rest }) => (
+const CloseBtn = ({ onClose, state: _, ...rest }) => (
 	<button onClick={() => onClose()} {...rest}>
 		Close <HouseIcon />
 	</button>

--- a/components/alert/examples/40-overrides.js
+++ b/components/alert/examples/40-overrides.js
@@ -10,7 +10,7 @@ const CloseBtn = ({ onClose, state: _, ...rest }) => (
 	</button>
 );
 
-const Heading = ({ children }) => (
+const HeadingOverride = ({ children }) => (
 	<h3
 		css={{
 			margin: '0 0 0.5rem 0',
@@ -21,7 +21,7 @@ const Heading = ({ children }) => (
 	</h3>
 );
 
-const Icon = ({ state: { look, icon }, ...rest }) => {
+const IconOverride = ({ state: { look, icon }, ...rest }) => {
 	const iconMap = {
 		success: TickIcon,
 		info: InfoIcon,
@@ -55,10 +55,10 @@ function Example({ brand }) {
 			}),
 		},
 		CloseBtn: {
-			component: CloseBtn,
+			component: CloseBtnOverride,
 		},
 		Heading: {
-			component: Heading,
+			component: HeadingOverride,
 		},
 	};
 

--- a/components/alert/src/overrides/alert.js
+++ b/components/alert/src/overrides/alert.js
@@ -3,7 +3,7 @@
 import { AlertIcon, InfoIcon, TickIcon } from '@westpac/icon';
 import { jsx, useBrand, useMediaQuery, getLabel } from '@westpac/core';
 
-const Alert = ({ state, ...rest }) => <div {...rest} />;
+const Alert = ({ state: _, ...rest }) => <div {...rest} />;
 
 const alertStyles = (_, { dismissible, look }) => {
 	const mq = useMediaQuery();

--- a/components/alert/src/overrides/body.js
+++ b/components/alert/src/overrides/body.js
@@ -3,7 +3,7 @@
 import { jsx, useMediaQuery, getLabel } from '@westpac/core';
 import { Body } from '@westpac/body';
 
-const AlertBody = ({ state, ...rest }) => <Body {...rest} />;
+const AlertBody = ({ state: _, ...rest }) => <Body {...rest} />;
 
 const bodyStyles = (_, { icon: Icon }) => {
 	const mq = useMediaQuery();

--- a/components/alert/src/overrides/closeBtn.js
+++ b/components/alert/src/overrides/closeBtn.js
@@ -4,7 +4,7 @@ import { jsx, useBrand, useMediaQuery, getLabel } from '@westpac/core';
 import { Button } from '@westpac/button';
 import { CloseIcon } from '@westpac/icon';
 
-const CloseBtn = ({ onClose, state, ...rest }) => (
+const CloseBtn = ({ onClose, state: _, ...rest }) => (
 	<Button
 		onClick={(event) => onClose(event)}
 		iconAfter={CloseIcon}

--- a/components/badge/src/overrides/badge.js
+++ b/components/badge/src/overrides/badge.js
@@ -7,7 +7,7 @@ import { defaultProps } from '../Badge';
 // Component
 // ==============================
 
-const Badge = ({ state, ...rest }) => <span {...rest} />;
+const Badge = ({ state: _, ...rest }) => <span {...rest} />;
 
 // ==============================
 // Styles

--- a/components/breadcrumb/examples/10-overrides.js
+++ b/components/breadcrumb/examples/10-overrides.js
@@ -4,7 +4,7 @@ import { GEL, jsx } from '@westpac/core';
 import { Breadcrumb, Crumb } from '@westpac/breadcrumb';
 import { HouseIcon } from '@westpac/icon';
 
-const Icon = ({ state, ...props }) => <HouseIcon color="red" {...props} />;
+const Icon = ({ state: _, ...props }) => <HouseIcon color="red" {...props} />;
 
 function Example({ brand }) {
 	const overridesWithTokens = { ...brand };

--- a/components/breadcrumb/src/overrides/breadcrumb.js
+++ b/components/breadcrumb/src/overrides/breadcrumb.js
@@ -2,7 +2,7 @@
 
 import { jsx, getLabel } from '@westpac/core';
 
-const Breadcrumb = ({ state, ...rest }) => <nav {...rest} />;
+const Breadcrumb = ({ state: _, ...rest }) => <nav {...rest} />;
 
 const breadcrumbStyles = () => ({
 	label: getLabel('breadcrumb'),

--- a/components/breadcrumb/src/overrides/crumb.js
+++ b/components/breadcrumb/src/overrides/crumb.js
@@ -2,7 +2,7 @@
 
 import { jsx, useBrand, getLabel } from '@westpac/core';
 
-const Crumb = ({ state, ...rest }) => <li {...rest} />;
+const Crumb = ({ state: _, ...rest }) => <li {...rest} />;
 
 const crumbStyles = () => {
 	const { COLORS } = useBrand();

--- a/components/breadcrumb/src/overrides/icon.js
+++ b/components/breadcrumb/src/overrides/icon.js
@@ -3,7 +3,7 @@
 import { jsx, useBrand, getLabel } from '@westpac/core';
 import { ArrowRightIcon } from '@westpac/icon';
 
-const Icon = ({ state, ...rest }) => {
+const Icon = ({ state: _, ...rest }) => {
 	const { COLORS } = useBrand();
 
 	return <ArrowRightIcon size="small" color={COLORS.primary} assistiveText={null} {...rest} />;

--- a/components/breadcrumb/src/overrides/list.js
+++ b/components/breadcrumb/src/overrides/list.js
@@ -2,7 +2,7 @@
 
 import { jsx, useBrand, getLabel } from '@westpac/core';
 
-const List = ({ state, ...props }) => <ol {...props} />;
+const List = ({ state: _, ...props }) => <ol {...props} />;
 
 const listStyles = () => {
 	const { SPACING } = useBrand();

--- a/components/button-dropdown/src/overrides/buttonDropdown.js
+++ b/components/button-dropdown/src/overrides/buttonDropdown.js
@@ -2,7 +2,7 @@
 
 import { jsx, getLabel } from '@westpac/core';
 
-const ButtonDropdown = ({ state, ...rest }) => <div {...rest} />;
+const ButtonDropdown = ({ state: _, ...rest }) => <div {...rest} />;
 
 const buttonDropdownStyles = (_, { block }) => ({
 	label: getLabel('buttonDropdown', { block }),

--- a/components/button-dropdown/src/overrides/panel.js
+++ b/components/button-dropdown/src/overrides/panel.js
@@ -3,7 +3,7 @@
 import { jsx, useMediaQuery, asArray, useBrand, getLabel } from '@westpac/core';
 import { forwardRef } from 'react';
 
-const Panel = forwardRef(({ state, ...rest }, ref) => <div ref={ref} {...rest} />);
+const Panel = forwardRef(({ state: _, ...rest }, ref) => <div ref={ref} {...rest} />);
 
 const panelStyles = (_, { open, dropdownSize }) => {
 	const mq = useMediaQuery();

--- a/components/button-group/src/overrides/buttonGroup.js
+++ b/components/button-group/src/overrides/buttonGroup.js
@@ -2,7 +2,7 @@
 
 import { jsx, asArray, useMediaQuery, getLabel } from '@westpac/core';
 
-const ButtonGroup = ({ state, ...rest }) => <div {...rest} />;
+const ButtonGroup = ({ state: _, ...rest }) => <div {...rest} />;
 
 const buttonGroupStyles = (_, { block }) => {
 	const mq = useMediaQuery();

--- a/components/button-group/src/overrides/item.js
+++ b/components/button-group/src/overrides/item.js
@@ -2,7 +2,7 @@
 
 import { jsx, asArray, useMediaQuery, getLabel } from '@westpac/core';
 
-const Item = ({ state, ...rest }) => <label {...rest} />;
+const Item = ({ state: _, ...rest }) => <label {...rest} />;
 
 export const itemStyles = (_, { block }) => {
 	const mq = useMediaQuery();

--- a/components/button/examples/90-overrides.js
+++ b/components/button/examples/90-overrides.js
@@ -5,7 +5,7 @@ import { Button } from '@westpac/button';
 import { HouseIcon } from '@westpac/icon';
 import { Fragment } from 'react';
 
-const ContentWrapper = ({ children, ...rest }) => (
+const ContentOverride = ({ children, ...rest }) => (
 	<Fragment>
 		{children}
 		<HouseIcon size="small" color="currentColor" css={{ marginLeft: '0.5em' }} />
@@ -22,7 +22,7 @@ function Example({ brand }) {
 			}),
 		},
 		Content: {
-			component: ContentWrapper,
+			component: ContentOverride,
 		},
 	};
 

--- a/components/button/src/overrides/content.js
+++ b/components/button/src/overrides/content.js
@@ -7,7 +7,7 @@ import { Fragment } from 'react';
 // Component
 // ==============================
 
-const Content = ({ state, children }) => <Fragment>{children}</Fragment>;
+const Content = ({ state: _, children }) => <Fragment>{children}</Fragment>;
 
 // ==============================
 // Styles

--- a/components/button/src/overrides/icon.js
+++ b/components/button/src/overrides/icon.js
@@ -6,7 +6,7 @@ import { jsx } from '@westpac/core';
 // Component
 // ==============================
 
-const Icon = ({ state, icon: Icon, left, right, ...rest }) => <Icon {...rest} />;
+const Icon = ({ icon: Icon, left, right, state: _, ...rest }) => <Icon {...rest} />;
 
 // ==============================
 // Styles

--- a/components/button/src/overrides/text.js
+++ b/components/button/src/overrides/text.js
@@ -6,7 +6,7 @@ import { jsx } from '@westpac/core';
 // Component
 // ==============================
 
-const Text = ({ state, ...rest }) => <span {...rest} />;
+const Text = ({ state: _, ...rest }) => <span {...rest} />;
 
 // ==============================
 // Styles

--- a/components/form-check/src/overrides/formCheck.js
+++ b/components/form-check/src/overrides/formCheck.js
@@ -2,7 +2,7 @@
 
 import { jsx, getLabel } from '@westpac/core';
 
-const FormCheck = ({ state, ...rest }) => <div {...rest} />;
+const FormCheck = ({ state: _, ...rest }) => <div {...rest} />;
 
 const formCheckStyles = () => ({
 	label: getLabel('formCheck'),

--- a/components/form-check/src/overrides/label.js
+++ b/components/form-check/src/overrides/label.js
@@ -2,7 +2,7 @@
 
 import { jsx, useBrand, getLabel } from '@westpac/core';
 
-const Label = ({ state, ...rest }) => <label {...rest} />;
+const Label = ({ state: _, ...rest }) => <label {...rest} />;
 
 const labelStyles = (_, { type, size }) => {
 	const { COLORS, PACKS } = useBrand();

--- a/components/form-check/src/overrides/option.js
+++ b/components/form-check/src/overrides/option.js
@@ -2,7 +2,7 @@
 
 import { jsx, getLabel } from '@westpac/core';
 
-const Option = ({ state, ...rest }) => <div {...rest} />;
+const Option = ({ state: _, ...rest }) => <div {...rest} />;
 
 const optionStyles = (_, { size, inline }) => {
 	const sizeMap = {

--- a/components/icon/examples/60-overrides.js
+++ b/components/icon/examples/60-overrides.js
@@ -14,7 +14,7 @@ import {
 } from '@westpac/icon';
 import { Fragment } from 'react';
 
-const Wrapper = ({ children, state: { icon }, ...rest }) => (
+const Wrapper = ({ state: { icon }, children, ...rest }) => (
 	<Fragment>
 		<div {...rest}>{children}</div>
 		<div css={{ marginBottom: '1rem' }}>

--- a/components/icon/src/overrides/icon.js
+++ b/components/icon/src/overrides/icon.js
@@ -2,7 +2,7 @@
 
 import { jsx, useBrand, useMediaQuery, asArray, getLabel } from '@westpac/core';
 
-const Icon = ({ state, ...rest }) => <span {...rest} />;
+const Icon = ({ state: _, ...rest }) => <span {...rest} />;
 
 const iconStyles = (_, { color, size }) => {
 	const mq = useMediaQuery();

--- a/components/input-group/examples/40-overrides.js
+++ b/components/input-group/examples/40-overrides.js
@@ -4,7 +4,7 @@ import { GEL, jsx } from '@westpac/core';
 import { HouseIcon } from '@westpac/icon';
 import { InputGroup, Before, After } from '@westpac/input-group';
 
-const Text = ({ data, overrides, ...rest }) => (
+const Text = ({ data, state: _, ...rest }) => (
 	<span {...rest}>
 		<HouseIcon size="small" /> {data}
 	</span>

--- a/components/input-group/examples/40-overrides.js
+++ b/components/input-group/examples/40-overrides.js
@@ -4,7 +4,7 @@ import { GEL, jsx } from '@westpac/core';
 import { HouseIcon } from '@westpac/icon';
 import { InputGroup, Before, After } from '@westpac/input-group';
 
-const Text = ({ data, state: _, ...rest }) => (
+const TextOverride = ({ data, state: _, ...rest }) => (
 	<span {...rest}>
 		<HouseIcon size="small" /> {data}
 	</span>
@@ -20,7 +20,7 @@ function Example({ brand }) {
 			}),
 		},
 		Text: {
-			component: Text,
+			component: TextOverride,
 		},
 		TextInput: {
 			styles: (styles) => ({

--- a/components/input-group/src/overrides/inputGroup.js
+++ b/components/input-group/src/overrides/inputGroup.js
@@ -2,7 +2,7 @@
 
 import { jsx, getLabel } from '@westpac/core';
 
-const InputGroup = ({ state, ...rest }) => <div {...rest} />;
+const InputGroup = ({ state: _, ...rest }) => <div {...rest} />;
 
 const inputGroupStyles = () => ({
 	label: getLabel('inputGroup'),

--- a/components/input-group/src/overrides/text.js
+++ b/components/input-group/src/overrides/text.js
@@ -2,7 +2,7 @@
 
 import { jsx, useBrand, getLabel } from '@westpac/core';
 
-const Text = ({ state, ...rest }) => <span {...rest} />;
+const Text = ({ state: _, ...rest }) => <span {...rest} />;
 
 const textStyles = (_, { size, position }) => {
 	const { COLORS } = useBrand();

--- a/components/label/examples/10-overrides.js
+++ b/components/label/examples/10-overrides.js
@@ -3,7 +3,7 @@
 import { GEL, jsx } from '@westpac/core';
 import { Label } from '@westpac/label';
 
-const LabelWithEdit = ({ state, look, value, children, ...rest }) => {
+const LabelWithEdit = ({ look, value, state: _, children, ...rest }) => {
 	return (
 		<span {...rest}>
 			{children}

--- a/components/label/examples/10-overrides.js
+++ b/components/label/examples/10-overrides.js
@@ -3,7 +3,7 @@
 import { GEL, jsx } from '@westpac/core';
 import { Label } from '@westpac/label';
 
-const LabelWithEdit = ({ look, value, state: _, children, ...rest }) => {
+const LabelOverride = ({ look, value, state: _, children, ...rest }) => {
 	return (
 		<span {...rest}>
 			{children}
@@ -46,7 +46,7 @@ function Example({ brand }) {
 				backgroundColor: look === 'neutral' ? 'rebeccapurple' : styles.backgroundColor,
 				outline: '3px solid blue',
 			}),
-			component: LabelWithEdit,
+			component: LabelOverride,
 		},
 	};
 

--- a/components/label/src/overrides/label.js
+++ b/components/label/src/overrides/label.js
@@ -2,7 +2,7 @@
 
 import { jsx, useBrand, getLabel } from '@westpac/core';
 
-const Label = ({ state, ...rest }) => <span {...rest} />;
+const Label = ({ state: _, ...rest }) => <span {...rest} />;
 
 const labelStyles = (_, { look }) => {
 	const { COLORS, TYPE } = useBrand();

--- a/components/list/src/overrides/item.js
+++ b/components/list/src/overrides/item.js
@@ -2,7 +2,7 @@
 
 import { jsx } from '@westpac/core';
 
-const Item = ({ state, ...rest }) => <li {...rest} />;
+const Item = ({ state: _, ...rest }) => <li {...rest} />;
 
 const itemStyles = (_, {}) => null;
 

--- a/components/modal/src/overrides/body.js
+++ b/components/modal/src/overrides/body.js
@@ -3,7 +3,7 @@
 import { jsx, useBrand } from '@westpac/core';
 import { Body } from '@westpac/body';
 
-const ModalBody = ({ state, ...rest }) => <Body {...rest} />;
+const ModalBody = ({ state: _, ...rest }) => <Body {...rest} />;
 
 const bodyStyles = () => {
 	const { TYPE, COLORS } = useBrand();

--- a/components/modal/src/overrides/closeBtn.js
+++ b/components/modal/src/overrides/closeBtn.js
@@ -4,7 +4,7 @@ import { jsx, useBrand } from '@westpac/core';
 import { Button } from '@westpac/button';
 import { CloseIcon } from '@westpac/icon';
 
-const CloseBtn = ({ state, ...rest }) => (
+const CloseBtn = ({ state: _, ...rest }) => (
 	<Button iconAfter={CloseIcon} look="link" size="medium" assistiveText="Close modal" {...rest} />
 );
 

--- a/components/modal/src/overrides/footer.js
+++ b/components/modal/src/overrides/footer.js
@@ -2,7 +2,7 @@
 
 import { jsx, useBrand } from '@westpac/core';
 
-const Footer = ({ state, ...rest }) => <div {...rest} />;
+const Footer = ({ state: _, ...rest }) => <div {...rest} />;
 
 const footerStyles = () => {
 	const { COLORS } = useBrand();

--- a/components/modal/src/overrides/header.js
+++ b/components/modal/src/overrides/header.js
@@ -2,7 +2,7 @@
 
 import { jsx, useBrand } from '@westpac/core';
 
-const Header = ({ state, ...rest }) => <div {...rest} />;
+const Header = ({ state: _, ...rest }) => <div {...rest} />;
 
 const headerStyles = () => {
 	const { COLORS } = useBrand();

--- a/components/modal/src/overrides/heading.js
+++ b/components/modal/src/overrides/heading.js
@@ -4,7 +4,7 @@ import { jsx, useBrand } from '@westpac/core';
 import { Heading } from '@westpac/heading';
 import { forwardRef } from 'react';
 
-const ModalHeading = forwardRef(({ state, ...rest }, ref) => (
+const ModalHeading = forwardRef(({ state: _, ...rest }, ref) => (
 	<Heading ref={ref} tag="h1" size={8} {...rest} />
 ));
 

--- a/components/pagination/src/overrides/list.js
+++ b/components/pagination/src/overrides/list.js
@@ -2,7 +2,7 @@
 
 import { jsx, getLabel } from '@westpac/core';
 
-const List = ({ state, ...rest }) => <ul {...rest} />;
+const List = ({ state: _, ...rest }) => <ul {...rest} />;
 
 const listStyles = () => ({
 	label: getLabel('pagination-list'),

--- a/components/pagination/src/overrides/page.js
+++ b/components/pagination/src/overrides/page.js
@@ -2,7 +2,7 @@
 
 import { jsx, getLabel } from '@westpac/core';
 
-const Page = ({ state, ...rest }) => <li {...rest} />;
+const Page = ({ state: _, ...rest }) => <li {...rest} />;
 
 const pageStyles = () => ({
 	label: getLabel('pagination-page'),

--- a/components/pagination/src/overrides/pagination.js
+++ b/components/pagination/src/overrides/pagination.js
@@ -2,7 +2,7 @@
 
 import { jsx, getLabel } from '@westpac/core';
 
-const Pagination = ({ state, ...rest }) => <nav {...rest} />;
+const Pagination = ({ state: _, ...rest }) => <nav {...rest} />;
 
 const paginationStyles = () => ({
 	label: getLabel('pagination'),

--- a/components/panel/examples/30-overrides.js
+++ b/components/panel/examples/30-overrides.js
@@ -3,7 +3,7 @@
 import { GEL, jsx } from '@westpac/core';
 import { Panel, Body, Footer } from '@westpac/panel';
 
-const Wrapper = ({ look, heading, headingTag, overrides, ...rest }) => <aside {...rest} />;
+const Wrapper = ({ state: _, ...rest }) => <aside {...rest} />;
 
 function Example({ brand }) {
 	const overridesWithTokens = { ...brand };

--- a/components/panel/examples/30-overrides.js
+++ b/components/panel/examples/30-overrides.js
@@ -3,7 +3,7 @@
 import { GEL, jsx } from '@westpac/core';
 import { Panel, Body, Footer } from '@westpac/panel';
 
-const Wrapper = ({ state: _, ...rest }) => <aside {...rest} />;
+const PanelOverride = ({ state: _, ...rest }) => <aside {...rest} />;
 
 function Example({ brand }) {
 	const overridesWithTokens = { ...brand };
@@ -15,7 +15,7 @@ function Example({ brand }) {
 				borderColor: 'palevioletred',
 				outline: '1px solid red',
 			}),
-			component: Wrapper,
+			component: PanelOverride,
 		},
 		Header: {
 			styles: (styles) => ({

--- a/components/panel/src/overrides/body.js
+++ b/components/panel/src/overrides/body.js
@@ -7,7 +7,7 @@ import { Body } from '@westpac/body';
 // Component
 // ==============================
 
-const PanelBody = ({ state, ...rest }) => <Body {...rest} />;
+const PanelBody = ({ state: _, ...rest }) => <Body {...rest} />;
 
 // ==============================
 // Styles

--- a/components/panel/src/overrides/footer.js
+++ b/components/panel/src/overrides/footer.js
@@ -6,7 +6,7 @@ import { jsx, useBrand, useMediaQuery } from '@westpac/core';
 // Component
 // ==============================
 
-const Footer = ({ state, ...rest }) => <div {...rest} />;
+const Footer = ({ state: _, ...rest }) => <div {...rest} />;
 
 // ==============================
 // Styles

--- a/components/panel/src/overrides/header.js
+++ b/components/panel/src/overrides/header.js
@@ -7,7 +7,7 @@ import { defaultProps } from '../Panel';
 // Component
 // ==============================
 
-const Header = ({ state, ...rest }) => <div {...rest} />;
+const Header = ({ state: _, ...rest }) => <div {...rest} />;
 
 // ==============================
 // Styles

--- a/components/panel/src/overrides/panel.js
+++ b/components/panel/src/overrides/panel.js
@@ -8,7 +8,7 @@ import { nestedStyles } from './header';
 // Component
 // ==============================
 
-const Panel = ({ state, ...rest }) => <div {...rest} />;
+const Panel = ({ state: _, ...rest }) => <div {...rest} />;
 
 // ==============================
 // Styles

--- a/components/pictogram/src/overrides/pictogram.js
+++ b/components/pictogram/src/overrides/pictogram.js
@@ -2,7 +2,7 @@
 
 import { jsx, useBrand, useMediaQuery, asArray, getLabel } from '@westpac/core';
 
-const Pictogram = ({ state, ...rest }) => <span {...rest} />;
+const Pictogram = ({ state: _, ...rest }) => <span {...rest} />;
 
 const pictogramStyles = () => {
 	const mq = useMediaQuery();

--- a/components/popover/src/overrides/body.js
+++ b/components/popover/src/overrides/body.js
@@ -3,7 +3,7 @@
 import { jsx, useBrand, getLabel } from '@westpac/core';
 import { Body } from '@westpac/body';
 
-const PopoverBody = ({ state, ...rest }) => <Body {...rest} />;
+const PopoverBody = ({ state: _, ...rest }) => <Body {...rest} />;
 
 const bodyStyles = (_, {}) => {
 	const { COLORS } = useBrand();

--- a/components/popover/src/overrides/closeBtn.js
+++ b/components/popover/src/overrides/closeBtn.js
@@ -4,7 +4,7 @@ import { jsx, useBrand, getLabel } from '@westpac/core';
 import { Button } from '@westpac/button';
 import { CloseIcon } from '@westpac/icon';
 
-const CloseBtn = ({ state, ...rest }) => (
+const CloseBtn = ({ state: _, ...rest }) => (
 	<Button iconAfter={CloseIcon} look="link" size="medium" assistiveText="Close popover" {...rest} />
 );
 

--- a/components/popover/src/overrides/panel.js
+++ b/components/popover/src/overrides/panel.js
@@ -3,7 +3,7 @@
 import { jsx, useBrand, getLabel } from '@westpac/core';
 import { forwardRef } from 'react';
 
-const Panel = forwardRef(({ state, ...rest }, ref) => <div ref={ref} {...rest} />);
+const Panel = forwardRef(({ state: _, ...rest }, ref) => <div ref={ref} {...rest} />);
 
 const panelStyles = (_, { open, position }) => {
 	const { COLORS } = useBrand();

--- a/components/popover/src/overrides/popover.js
+++ b/components/popover/src/overrides/popover.js
@@ -2,7 +2,7 @@
 
 import { jsx, getLabel } from '@westpac/core';
 
-const Popover = ({ state, ...rest }) => <div {...rest} />;
+const Popover = ({ state: _, ...rest }) => <div {...rest} />;
 
 const popoverStyles = () => ({
 	label: getLabel('popover'),

--- a/components/popover/src/overrides/trigger.js
+++ b/components/popover/src/overrides/trigger.js
@@ -4,7 +4,7 @@ import { jsx } from '@westpac/core';
 import { Button } from '@westpac/button';
 import { forwardRef } from 'react';
 
-const Trigger = forwardRef(({ state, ...rest }, ref) => <Button ref={ref} {...rest} />);
+const Trigger = forwardRef(({ state: _, ...rest }, ref) => <Button ref={ref} {...rest} />);
 
 const triggerStyles = () => ({});
 

--- a/components/progress-bar/src/overrides/bar.js
+++ b/components/progress-bar/src/overrides/bar.js
@@ -2,7 +2,7 @@
 
 import { jsx, useBrand, getLabel } from '@westpac/core';
 
-const Bar = ({ state, ...rest }) => <div {...rest} />;
+const Bar = ({ state: _, ...rest }) => <div {...rest} />;
 
 const barStyles = (_, { look }) => {
 	const { COLORS, TYPE } = useBrand();

--- a/components/progress-bar/src/overrides/progressBar.js
+++ b/components/progress-bar/src/overrides/progressBar.js
@@ -2,7 +2,7 @@
 
 import { jsx, useBrand, getLabel } from '@westpac/core';
 
-export const ProgressBar = ({ state, ...rest }) => <div {...rest} />;
+export const ProgressBar = ({ state: _, ...rest }) => <div {...rest} />;
 
 export const progressBarStyles = (_, { look }) => {
 	const { COLORS } = useBrand();

--- a/components/progress-bar/src/overrides/text.js
+++ b/components/progress-bar/src/overrides/text.js
@@ -2,7 +2,7 @@
 
 import { jsx, getLabel } from '@westpac/core';
 
-const Text = ({ state, ...rest }) => <span {...rest} />;
+const Text = ({ state: _, ...rest }) => <span {...rest} />;
 
 const textStyles = () => ({
 	label: getLabel('progressBar-text'),

--- a/components/progress-rope/src/overrides/group.js
+++ b/components/progress-rope/src/overrides/group.js
@@ -13,7 +13,7 @@ import { stepStyles } from './step';
 // Component
 // ==============================
 
-const Group = ({ state, ...rest }) => <li {...rest} />;
+const Group = ({ state: _, ...rest }) => <li {...rest} />;
 
 // ==============================
 // Styles

--- a/components/progress-rope/src/overrides/groupButtonWrapper.js
+++ b/components/progress-rope/src/overrides/groupButtonWrapper.js
@@ -6,7 +6,7 @@ import { jsx } from '@westpac/core';
 // Component
 // ==============================
 
-const GroupButtonWrapper = ({ state, ...rest }) => <h3 {...rest} />;
+const GroupButtonWrapper = ({ state: _, ...rest }) => <h3 {...rest} />;
 
 // ==============================
 // Styles

--- a/components/progress-rope/src/overrides/groupList.js
+++ b/components/progress-rope/src/overrides/groupList.js
@@ -6,7 +6,7 @@ import { jsx } from '@westpac/core';
 // Component
 // ==============================
 
-const GroupList = ({ state, ...rest }) => <ol {...rest} />;
+const GroupList = ({ state: _, ...rest }) => <ol {...rest} />;
 
 // ==============================
 // Styles

--- a/components/progress-rope/src/overrides/list.js
+++ b/components/progress-rope/src/overrides/list.js
@@ -6,7 +6,7 @@ import { jsx, useBrand } from '@westpac/core';
 // Component
 // ==============================
 
-const List = ({ state, ...rest }) => <ol {...rest} />;
+const List = ({ state: _, ...rest }) => <ol {...rest} />;
 
 // ==============================
 // Styles

--- a/components/progress-rope/src/overrides/progressRope.js
+++ b/components/progress-rope/src/overrides/progressRope.js
@@ -6,7 +6,7 @@ import { jsx } from '@westpac/core';
 // Component
 // ==============================
 
-const ProgressRope = ({ state, ...rest }) => <nav role="navigation" {...rest} />;
+const ProgressRope = ({ state: _, ...rest }) => <nav role="navigation" {...rest} />;
 
 // ==============================
 // Styles

--- a/components/progress-rope/src/overrides/step.js
+++ b/components/progress-rope/src/overrides/step.js
@@ -9,7 +9,7 @@ import { getStyles } from './_utils';
 // Component
 // ==============================
 
-const Step = ({ state, ...rest }) => <li {...rest} />;
+const Step = ({ state: _, ...rest }) => <li {...rest} />;
 
 // ==============================
 // Styles

--- a/components/switch/examples/60-overrides.js
+++ b/components/switch/examples/60-overrides.js
@@ -4,14 +4,14 @@ import { useState } from 'react';
 import { GEL, jsx } from '@westpac/core';
 import { Switch } from '@westpac/switch';
 
-const Label = ({ state: _, ...rest }) => <strong {...rest} />;
+const LabelOverride = ({ state: _, ...rest }) => <strong {...rest} />;
 
 function Example({ brand }) {
 	const overridesWithTokens = { ...brand };
 
 	overridesWithTokens['@westpac/switch'] = {
 		Label: {
-			component: Label,
+			component: LabelOverride,
 			styles: (styles) => ({
 				...styles,
 				color: 'palevioletred',

--- a/components/switch/examples/60-overrides.js
+++ b/components/switch/examples/60-overrides.js
@@ -4,7 +4,7 @@ import { useState } from 'react';
 import { GEL, jsx } from '@westpac/core';
 import { Switch } from '@westpac/switch';
 
-const Label = ({ state, ...rest }) => <strong {...rest} />;
+const Label = ({ state: _, ...rest }) => <strong {...rest} />;
 
 function Example({ brand }) {
 	const overridesWithTokens = { ...brand };

--- a/components/switch/src/overrides/label.js
+++ b/components/switch/src/overrides/label.js
@@ -2,7 +2,7 @@
 
 import { jsx } from '@westpac/core';
 
-const Label = ({ state, ...rest }) => <span {...rest} />;
+const Label = ({ state: _, ...rest }) => <span {...rest} />;
 
 const labelStyles = (_, { block }) => {
 	return {

--- a/components/switch/src/overrides/switch.js
+++ b/components/switch/src/overrides/switch.js
@@ -3,7 +3,7 @@
 import { jsx, useMediaQuery } from '@westpac/core';
 import { sizeMap } from './_utils';
 
-const Switch = ({ state, ...rest }) => <label {...rest} />;
+const Switch = ({ state: _, ...rest }) => <label {...rest} />;
 
 const switchStyles = (_, { block, disabled, size }) => {
 	const mq = useMediaQuery();

--- a/components/switch/src/overrides/toggle.js
+++ b/components/switch/src/overrides/toggle.js
@@ -3,7 +3,7 @@
 import { jsx, useBrand, useMediaQuery } from '@westpac/core';
 import { sizeMap } from './_utils';
 
-const Toggle = ({ state, ...rest }) => <span {...rest} />;
+const Toggle = ({ state: _, ...rest }) => <span {...rest} />;
 
 const toggleStyles = (_, { size, checked }) => {
 	const mq = useMediaQuery();

--- a/components/symbol/examples/40-overrides.js
+++ b/components/symbol/examples/40-overrides.js
@@ -11,7 +11,7 @@ import {
 import { Cell, Grid, Name } from './_utils';
 import { Fragment } from 'react';
 
-const Wrapper = ({ children, symbol, state, ...rest }) => (
+const Wrapper = ({ symbol, state: _, children, ...rest }) => (
 	<Fragment>
 		<div {...rest}>{children}</div>
 		<div css={{ marginBottom: '1rem' }}>

--- a/components/symbol/examples/40-overrides.js
+++ b/components/symbol/examples/40-overrides.js
@@ -11,7 +11,7 @@ import {
 import { Cell, Grid, Name } from './_utils';
 import { Fragment } from 'react';
 
-const Wrapper = ({ symbol, state: _, children, ...rest }) => (
+const SymbolOverride = ({ symbol, state: _, children, ...rest }) => (
 	<Fragment>
 		<div {...rest}>{children}</div>
 		<div css={{ marginBottom: '1rem' }}>
@@ -28,7 +28,7 @@ function Example({ brand }) {
 				...styles,
 				outline: '1px solid red',
 			}),
-			component: Wrapper,
+			component: SymbolOverride,
 		},
 	};
 

--- a/components/symbol/src/overrides/svg.js
+++ b/components/symbol/src/overrides/svg.js
@@ -2,7 +2,7 @@
 
 import { jsx } from '@westpac/core';
 
-const Svg = ({ state, ...rest }) => <svg {...rest} />;
+const Svg = ({ state: _, ...rest }) => <svg {...rest} />;
 
 const svgStyles = () => ({
 	width: '100%',

--- a/components/symbol/src/overrides/symbol.js
+++ b/components/symbol/src/overrides/symbol.js
@@ -2,7 +2,7 @@
 
 import { jsx, useMediaQuery, asArray } from '@westpac/core';
 
-const Symbol = ({ symbol, state, ...rest }) => <span {...rest} />;
+const Symbol = ({ symbol, state: _, ...rest }) => <span {...rest} />;
 
 const symbolStyles = (_, { width, height, viewBoxWidth, viewBoxHeight }) => {
 	const mq = useMediaQuery();

--- a/components/tabcordion/src/overrides/accordionButton.js
+++ b/components/tabcordion/src/overrides/accordionButton.js
@@ -2,7 +2,7 @@
 
 import { jsx, useBrand } from '@westpac/core';
 
-const AccordionButton = ({ state, ...rest }) => <button type="button" {...rest} />;
+const AccordionButton = ({ state: _, ...rest }) => <button type="button" {...rest} />;
 
 const accordionButtonStyles = (_, { look, last, hidden }) => {
 	const { COLORS } = useBrand();

--- a/components/tabcordion/src/overrides/panel.js
+++ b/components/tabcordion/src/overrides/panel.js
@@ -3,7 +3,7 @@
 import { forwardRef } from 'react';
 import { jsx, useBrand } from '@westpac/core';
 
-const Panel = forwardRef(({ state, ...rest }, ref) => <div ref={ref} {...rest} />);
+const Panel = forwardRef(({ state: _, ...rest }, ref) => <div ref={ref} {...rest} />);
 
 const panelStyles = (_, { look, mode, last, selected }) => {
 	const { COLORS } = useBrand();

--- a/components/tabcordion/src/overrides/tabButton.js
+++ b/components/tabcordion/src/overrides/tabButton.js
@@ -3,7 +3,7 @@
 import { forwardRef } from 'react';
 import { jsx, useBrand } from '@westpac/core';
 
-const TabButton = forwardRef(({ state, ...rest }, ref) => {
+const TabButton = forwardRef(({ state: _, ...rest }, ref) => {
 	return <button type="button" ref={ref} {...rest} />;
 });
 

--- a/components/tabcordion/src/overrides/tabRow.js
+++ b/components/tabcordion/src/overrides/tabRow.js
@@ -3,7 +3,7 @@
 import { forwardRef } from 'react';
 import { jsx } from '@westpac/core';
 
-const TabRow = forwardRef(({ state, ...rest }, ref) => <div ref={ref} {...rest} />);
+const TabRow = forwardRef(({ state: _, ...rest }, ref) => <div ref={ref} {...rest} />);
 
 const tabRowStyles = () => ({
 	display: 'flex',

--- a/components/tabcordion/src/overrides/tabcordion.js
+++ b/components/tabcordion/src/overrides/tabcordion.js
@@ -3,7 +3,7 @@
 import { forwardRef } from 'react';
 import { jsx } from '@westpac/core';
 
-const Tabcordion = forwardRef(({ state, ...rest }, ref) => <div ref={ref} {...rest} />);
+const Tabcordion = forwardRef(({ state: _, ...rest }, ref) => <div ref={ref} {...rest} />);
 
 const tabcordionStyles = () => ({});
 

--- a/components/table/src/overrides/caption.js
+++ b/components/table/src/overrides/caption.js
@@ -2,7 +2,7 @@
 
 import { jsx, useBrand } from '@westpac/core';
 
-const Caption = ({ state, ...rest }) => <caption {...rest} />;
+const Caption = ({ state: _, ...rest }) => <caption {...rest} />;
 
 const captionStyles = () => {
 	const { TYPE } = useBrand();

--- a/components/table/src/overrides/table.js
+++ b/components/table/src/overrides/table.js
@@ -3,7 +3,7 @@
 import { jsx, useBrand } from '@westpac/core';
 import { Body } from '@westpac/body';
 
-const Table = ({ state, ...rest }) => <Body tag="table" {...rest} />;
+const Table = ({ state: _, ...rest }) => <Body tag="table" {...rest} />;
 
 const tableStyles = (_, { striped }) => {
 	const { COLORS } = useBrand();

--- a/components/table/src/overrides/tbody.js
+++ b/components/table/src/overrides/tbody.js
@@ -2,7 +2,7 @@
 
 import { jsx } from '@westpac/core';
 
-const Tbody = ({ state, ...rest }) => <tbody {...rest} />;
+const Tbody = ({ state: _, ...rest }) => <tbody {...rest} />;
 
 const tbodyStyles = () => ({});
 

--- a/components/table/src/overrides/td.js
+++ b/components/table/src/overrides/td.js
@@ -2,7 +2,7 @@
 
 import { jsx, useBrand } from '@westpac/core';
 
-const Td = ({ state, ...rest }) => <td {...rest} />;
+const Td = ({ state: _, ...rest }) => <td {...rest} />;
 
 const tdStyles = (_, { highlighted, highlightStart, bordered }) => {
 	const { COLORS, TYPE } = useBrand();

--- a/components/table/src/overrides/tfoot.js
+++ b/components/table/src/overrides/tfoot.js
@@ -2,7 +2,7 @@
 
 import { jsx, useBrand } from '@westpac/core';
 
-const TFoot = ({ state, ...rest }) => <tfoot {...rest} />;
+const TFoot = ({ state: _, ...rest }) => <tfoot {...rest} />;
 
 const tfootStyles = (_, { bordered }) => {
 	const { COLORS } = useBrand();

--- a/components/table/src/overrides/th.js
+++ b/components/table/src/overrides/th.js
@@ -2,7 +2,7 @@
 
 import { jsx, useBrand } from '@westpac/core';
 
-const Th = ({ state, ...rest }) => <th {...rest} />;
+const Th = ({ state: _, ...rest }) => <th {...rest} />;
 
 const thStyles = (_, { bordered }) => {
 	const { COLORS } = useBrand();

--- a/components/table/src/overrides/thead.js
+++ b/components/table/src/overrides/thead.js
@@ -2,7 +2,7 @@
 
 import { jsx, useBrand } from '@westpac/core';
 
-const Thead = ({ state, ...rest }) => <thead {...rest} />;
+const Thead = ({ state: _, ...rest }) => <thead {...rest} />;
 
 const theadStyles = (_, { bordered }) => {
 	const { COLORS, TYPE } = useBrand();

--- a/components/table/src/overrides/tr.js
+++ b/components/table/src/overrides/tr.js
@@ -2,7 +2,7 @@
 
 import { jsx, useBrand } from '@westpac/core';
 
-export const Tr = ({ state, ...rest }) => <tr {...rest} />;
+export const Tr = ({ state: _, ...rest }) => <tr {...rest} />;
 
 export const trStyles = (_, { striped, highlighted }) => {
 	const { COLORS } = useBrand();

--- a/components/table/src/overrides/wrapper.js
+++ b/components/table/src/overrides/wrapper.js
@@ -2,7 +2,7 @@
 
 import { jsx, useBrand } from '@westpac/core';
 
-const Wrapper = ({ state, ...rest }) => <div {...rest} />;
+const Wrapper = ({ state: _, ...rest }) => <div {...rest} />;
 
 const wrapperStyles = () => {
 	const { COLORS } = useBrand();

--- a/components/text-input/src/overrides/select.js
+++ b/components/text-input/src/overrides/select.js
@@ -4,7 +4,7 @@ import { jsx, useBrand, useMediaQuery } from '@westpac/core';
 import svgToTinyDataURI from 'mini-svg-data-uri';
 import { round, sizeMap } from '../_utils';
 
-const Select = ({ state, ...rest }) => <select {...rest} />;
+const Select = ({ state: _, ...rest }) => <select {...rest} />;
 
 const selectStyles = (_, { size, width, inline, invalid, ...rest }) => {
 	const { COLORS, PACKS, TYPE } = useBrand();

--- a/components/text-input/src/overrides/textInput.js
+++ b/components/text-input/src/overrides/textInput.js
@@ -3,7 +3,7 @@
 import { jsx, useBrand, useMediaQuery } from '@westpac/core';
 import { round, sizeMap } from '../_utils';
 
-const TextInput = ({ state, ...rest }) => <input {...rest} />;
+const TextInput = ({ state: _, ...rest }) => <input {...rest} />;
 
 const textInputStyles = (_, { size, width, inline, invalid, ...rest }) => {
 	const { COLORS, PACKS, TYPE } = useBrand();

--- a/components/text-input/src/overrides/textarea.js
+++ b/components/text-input/src/overrides/textarea.js
@@ -3,7 +3,7 @@
 import { jsx, useBrand, useMediaQuery } from '@westpac/core';
 import { round, sizeMap } from '../_utils';
 
-const Textarea = ({ state, ...rest }) => <textarea {...rest} />;
+const Textarea = ({ state: _, ...rest }) => <textarea {...rest} />;
 
 const textareaStyles = (_, { size, width, inline, invalid, ...rest }) => {
 	const { COLORS, PACKS, TYPE } = useBrand();


### PR DESCRIPTION
- rename destructured state props as _ and ensure prop order is consistent
- rename component override examples to be consistent