### PR TITLE
BrandHeading uppercase option

### DIFF
--- a/.changeset/ninety-owls-cry.md
+++ b/.changeset/ninety-owls-cry.md
@@ -1,0 +1,5 @@
+---
+'@westpac/heading': minor
+---
+
+Add new BrandHeading uppercase option

--- a/components/heading/src/BrandHeading.js
+++ b/components/heading/src/BrandHeading.js
@@ -12,7 +12,7 @@ import pkg from '../package.json';
 // ==============================
 
 export const BrandHeading = forwardRef(
-	({ tag, size, children, overrides: componentOverrides, ...rest }, ref) => {
+	({ tag, size, uppercase, children, overrides: componentOverrides, ...rest }, ref) => {
 		const {
 			OVERRIDES: { [pkg.name]: tokenOverrides },
 			[pkg.name]: brandOverrides,
@@ -25,6 +25,7 @@ export const BrandHeading = forwardRef(
 		const state = {
 			tag,
 			size,
+			uppercase,
 			overrides: componentOverrides,
 			...rest,
 		};
@@ -68,6 +69,13 @@ BrandHeading.propTypes = {
 		PropTypes.oneOf([1, 2, 3, 4, 5, 6, 7]),
 		PropTypes.arrayOf(PropTypes.oneOf([1, 2, 3, 4, 5, 6, 7])),
 	]).isRequired,
+
+	/**
+	 * Use upper case.
+	 *
+	 * This mode will also adjust line-height to suit.
+	 */
+	uppercase: PropTypes.bool,
 
 	/**
 	 * The override API

--- a/components/heading/src/overrides/brandHeading.js
+++ b/components/heading/src/overrides/brandHeading.js
@@ -25,7 +25,7 @@ const BrandHeading = forwardRef(({ state: { tag: Tag, size }, ...rest }, ref) =>
 	return <Tag ref={ref} {...rest} />;
 });
 
-const brandHeadingStyles = (_, { size }) => {
+const brandHeadingStyles = (_, { size, uppercase }) => {
 	const { PACKS, TYPE } = useBrand();
 	const mq = useMediaQuery();
 
@@ -49,8 +49,9 @@ const brandHeadingStyles = (_, { size }) => {
 		label: getLabel('brandHeading', { size }),
 		fontFamily: sizeArr.map((s) => s && PACKS.typeScale.brandFont[s].fontFamily),
 		fontSize: sizeArr.map((s) => s && PACKS.typeScale.brandFont[s].fontSize),
-		lineHeight: sizeArr.map((s) => s && PACKS.typeScale.brandFont[s].lineHeight),
+		lineHeight: uppercase ? 1 : sizeArr.map((s) => s && PACKS.typeScale.brandFont[s].lineHeight),
 		fontWeight: TYPE.brandFont.headingWeight,
+		textTransform: uppercase && 'uppercase',
 		margin: 0,
 	})[0];
 };

--- a/website/src/brand-overrides.js
+++ b/website/src/brand-overrides.js
@@ -14,15 +14,5 @@ export const brandOverrides = (brand) => {
 		},
 	}; */
 
-	overridesWithTokens['@westpac/heading'] = {
-		BrandHeading: {
-			styles: (styles) => ({
-				...styles,
-				textTransform: BRAND == 'WBC' && 'uppercase',
-				lineHeight: BRAND == 'WBC' && '1 !important',
-			}),
-		},
-	};
-
 	return overridesWithTokens;
 };

--- a/website/src/components/header/home-page-header.js
+++ b/website/src/components/header/home-page-header.js
@@ -263,6 +263,7 @@ const HeroIntro = () => {
 					<BrandHeading
 						tag="h2"
 						size={[4, null, 1]}
+						uppercase={BRAND === 'WBC'}
 						css={mq({
 							...(BRAND === 'WBC' && {
 								fontSize: ['3rem', null, '4.5rem'],

--- a/website/src/components/header/page-header.js
+++ b/website/src/components/header/page-header.js
@@ -165,7 +165,11 @@ const PageHeader = ({ name }) => {
 					})}
 				>
 					{BRAND === 'WBC' ? (
-						<BrandHeading tag="h1" size={[7, null, !hasScrolledLarge ? 2 : null]}>
+						<BrandHeading
+							tag="h1"
+							size={[7, null, !hasScrolledLarge ? 2 : null]}
+							uppercase={BRAND === 'WBC'}
+						>
 							{name}
 						</BrandHeading>
 					) : (


### PR DESCRIPTION
New `uppercase` prop that puts the BrandHeading in `text-transform: uppercase` and `line-height: 1` as required by our brands