### PR TITLE
Fix website body styling

### DIFF
--- a/website/src/pages/design-system/[...page].js
+++ b/website/src/pages/design-system/[...page].js
@@ -86,7 +86,7 @@ const Tabs = ({ component, tabName }) => {
 		);
 	});
 
-	const tabOverrides = {
+	const tabcordionOverrides = {
 		Tabcordion: {
 			styles: (styles) => ({
 				...styles,
@@ -118,8 +118,8 @@ const Tabs = ({ component, tabName }) => {
 					alignItems: 'center',
 					height: [54, null, 66],
 					borderRadius: 0,
-					backgroundColor: 'white',
-					border: 'none',
+					border: 0,
+					backgroundColor: 'transparent',
 					margin: 0,
 					borderRight: `solid 1px ${COLORS.border}`,
 					padding: [0, null, `0 ${SPACING(10)}`],
@@ -130,11 +130,14 @@ const Tabs = ({ component, tabName }) => {
 					':last-child': {
 						borderRightColor: ['#fff', null, `${COLORS.border}`],
 					},
+					':hover': {
+						backgroundColor: undefined, //strip
+					},
 				}),
 		},
 	};
 
-	const Panel = forwardRef(({ state, children, ...rest }, ref) => {
+	const PanelOverride = forwardRef(({ state, children, ...rest }, ref) => {
 		const { showGrid } = usePageContext();
 		return (
 			<div ref={ref} {...rest}>
@@ -144,16 +147,20 @@ const Tabs = ({ component, tabName }) => {
 		);
 	});
 
-	const overrides = {
+	const PanelBodyOverride = ({ state: _, setPanelHeight, ...rest }) => <div {...rest} />;
+
+	const tabOverrides = {
 		Panel: {
+			component: PanelOverride,
 			styles: (styles) => ({
 				...styles,
-				position: 'relative',
-				padding: 0,
-				margin: '0 auto',
-				border: 'none',
+				border: undefined, //strip
+				borderWidth: undefined, //strip
 			}),
-			component: Panel,
+		},
+		PanelBody: {
+			component: PanelBodyOverride,
+			styles: () => null, //remove all styling
 		},
 	};
 
@@ -173,20 +180,20 @@ const Tabs = ({ component, tabName }) => {
 
 	const tabs = [];
 	tabs.push(
-		<Tab key={'design-tab'} overrides={overrides} text="Design">
+		<Tab key={'design-tab'} overrides={tabOverrides} text="Design">
 			<DesignTab description={component.description} blocks={component.design} item={component} />
 		</Tab>
 	);
 	if (!component.hideAccessibilityTab) {
 		tabs.push(
-			<Tab key={'accessibility-tab'} overrides={overrides} text="Accessibility">
+			<Tab key={'accessibility-tab'} overrides={tabOverrides} text="Accessibility">
 				<AccessibilityTab blocks={component.accessibility} item={component} />
 			</Tab>
 		);
 	}
 	if (!component.hideCodeTab) {
 		tabs.push(
-			<Tab key={'code-tab'} overrides={overrides} text="Code">
+			<Tab key={'code-tab'} overrides={tabOverrides} text="Code">
 				<CodeTab blocks={component.code} item={component} />
 			</Tab>
 		);
@@ -203,7 +210,7 @@ const Tabs = ({ component, tabName }) => {
 				mode="tabs"
 				openTab={tabName ? tabMap.indexOf(tabName) : 0}
 				onOpen={onOpen}
-				overrides={tabOverrides}
+				overrides={tabcordionOverrides}
 			>
 				{tabs}
 			</Tabcordion>


### PR DESCRIPTION
Strips tabcordion PanelBody styling, removes use of <Body /> component and overrides tabButton styling

Fixes:
- broken breadcrumb styling in example box
- incorrect page padding
- tabButton hover styling