### PR TITLE
Dom/page tabs

### DIFF
--- a/components/tabcordion/examples/50-callbacks.js
+++ b/components/tabcordion/examples/50-callbacks.js
@@ -77,6 +77,7 @@ function Example({ brand }) {
 			<hr />
 			<Tabcordion
 				mode="accordion"
+				openTab={1}
 				onOpen={onOpen}
 				onOpening={onOpening}
 				onClose={onClose}

--- a/components/tabcordion/src/Tabcordion.js
+++ b/components/tabcordion/src/Tabcordion.js
@@ -58,7 +58,9 @@ export const Tabcordion = ({
 	};
 
 	const [activeTabIndex, setActiveTabIndex] = useState(openTab);
-	const [instanceId, setInstanceId] = useState(instanceIdPrefix);
+	const [instanceId, setInstanceId] = useState(
+		instanceIdPrefix ? instanceIdPrefix : `gel-tabcordion-${useInstanceId()}`
+	);
 
 	const containerRef = useRef();
 	const panelRef = useRef();
@@ -69,13 +71,6 @@ export const Tabcordion = ({
 		tabcordionMode !== 'responsive' ? tabcordionMode : width < 768 ? 'accordion' : 'tabs';
 
 	const setActive = (idx) => () => setActiveTabIndex(idx);
-
-	// create the prefix for internal IDs
-	useEffect(() => {
-		if (!instanceIdPrefix) {
-			setInstanceId(`gel-tabcordion-${useInstanceId()}`);
-		}
-	}, [instanceIdPrefix]);
 
 	useEffect(() => setActiveTabIndex(openTab), [openTab]);
 

--- a/website/src/components/pages/single-component/blocks-hub.js
+++ b/website/src/components/pages/single-component/blocks-hub.js
@@ -27,12 +27,12 @@ const ApplyShortCodes = ({ text }) => {
 	const textCodes = [...text.matchAll(/\[\[[A-Za-z0-9]*\]\]/g)].map((m) => m[0]);
 	let shortCodedText = text;
 
-	textCodes.forEach((shortCode) => {
+	textCodes.forEach((shortCode, index) => {
 		shortCodedText = reactStringReplace(shortCodedText, shortCode, (match, i) => {
 			const code = shortCode.slice(2, shortCode.length - 2);
 			if (typeof shortcodes[code] === 'function') {
 				const Component = shortcodes[code];
-				return <Component />;
+				return <Component key={`${shortCodedText}${index}`} />;
 			} else {
 				return shortcodes[code] || code;
 			}

--- a/website/src/pages/_app.js
+++ b/website/src/pages/_app.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import { ApolloProvider } from '@apollo/react-hooks';
 import cookie from 'cookie';
 import { Layout as DefaultLayout } from '../components/layout';
@@ -19,7 +19,8 @@ const getApolloClient = (initialState) =>
 
 const GELApp = ({ Component, pageProps, apollo, brand }) => {
 	const Layout = Component.layout || DefaultLayout;
-	const apolloClient = apollo || getApolloClient();
+	const apolloClient = useMemo(() => apollo || getApolloClient(), [apollo]);
+
 	return (
 		<ApolloProvider client={apolloClient}>
 			<Layout {...pageProps} brand={brand}>

--- a/website/src/pages/design-system/[...page].js
+++ b/website/src/pages/design-system/[...page].js
@@ -78,13 +78,18 @@ const Tabs = ({ component, tabName }) => {
 		};
 	}, []);
 
-	const onOpen = useCallback(({ idx: tabIdx }) => {
-		window.history.pushState(
-			null,
-			'',
-			`${router.asPath.split('?')[0]}?b=${brandName}&tab=${tabMap[tabIdx]}`
-		);
-	});
+	const onOpen = useCallback(
+		({ idx: tabIdx }) => {
+			if (tabMap[tabIdx] !== tabName) {
+				router.replace(
+					`${router.pathname}?b=${brandName}&tab=${tabMap[tabIdx]}`,
+					`${router.asPath.split('?')[0]}?b=${brandName}&tab=${tabMap[tabIdx]}`,
+					{ shallow: true }
+				);
+			}
+		},
+		[brandName, tabName]
+	);
 
 	const tabcordionOverrides = {
 		Tabcordion: {


### PR DESCRIPTION
Closing https://trello.com/c/kZtNDkSb/110-dom-website-routing

This will enable the navigation of the in-page tabs without them being handled as a page in the browser.
Mitchell helped me with fixing a bug where each page reload would also re-instantiate the apollo client which would make the site much slower than it should be. It also helps with using the router of next better without having it refresh the entire page.

This PR includes also a fix to tabcordion itself where `instanceIdPrefix` would cause a re-render even when it's not used and a fix to the pesky react error complaining about the missing `key` to an iteratable react component.