### PR TITLE
Remove button-group faint look option

### DIFF
--- a/components/button-group/src/ButtonGroup.js
+++ b/components/button-group/src/ButtonGroup.js
@@ -174,7 +174,7 @@ ButtonGroup.propTypes = {
 	/**
 	 * Button look. Passed on to each child button
 	 */
-	look: PropTypes.oneOf(['primary', 'hero', 'faint']).isRequired,
+	look: PropTypes.oneOf(['primary', 'hero']).isRequired,
 
 	/**
 	 * Button size. Passed on to each child button

--- a/components/button-group/src/overrides/button.js
+++ b/components/button-group/src/overrides/button.js
@@ -103,15 +103,6 @@ const blenderStyles = () => {
 					backgroundColor: COLORS.tints.primary50,
 				},
 			},
-			'&.__convert__button-faint-soft': {
-				color: COLORS.muted,
-				backgroundColor: COLORS.light,
-				borderColor: COLORS.border,
-
-				':hover, :active, &.active': {
-					backgroundColor: '#fff',
-				},
-			},
 		},
 		'input:disabled + &': {
 			opacity: '0.5',


### PR DESCRIPTION
This was never intended to be an option. It was never communicated. 

Issue: It's not clear enough when a button is selected, and is not accessible.