### PR TITLE
Update system font stack

### DIFF
--- a/.changeset/fresh-cooks-punch.md
+++ b/.changeset/fresh-cooks-punch.md
@@ -1,0 +1,11 @@
+---
+'@westpac/bom': minor
+'@westpac/bsa': minor
+'@westpac/btfg': minor
+'@westpac/rams': minor
+'@westpac/stg': minor
+'@westpac/wbc': minor
+'@westpac/wbg': minor
+---
+
+Update system font stack (bodyFont), now consistent with GEL2

--- a/.changeset/fresh-cooks-punch.md
+++ b/.changeset/fresh-cooks-punch.md
@@ -8,4 +8,4 @@
 '@westpac/wbg': minor
 ---
 
-Update system font stack (bodyFont), now consistent with GEL2
+Update system font stack (bodyFont)

--- a/brands/BOM/tokens/type.js
+++ b/brands/BOM/tokens/type.js
@@ -1,5 +1,5 @@
 const systemFont =
-	'-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif';
+	'-apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol"';
 
 module.exports = {
 	TYPE: {

--- a/brands/BOM/tokens/type.js
+++ b/brands/BOM/tokens/type.js
@@ -1,5 +1,5 @@
 const systemFont =
-	'-apple-system, BlinkMacSystemFont, "Helvetica Neue", Helvetica, Arial, sans-serif';
+	'-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif';
 
 module.exports = {
 	TYPE: {

--- a/brands/BSA/tokens/type.js
+++ b/brands/BSA/tokens/type.js
@@ -1,5 +1,5 @@
 const systemFont =
-	'-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif';
+	'-apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol"';
 
 module.exports = {
 	TYPE: {

--- a/brands/BSA/tokens/type.js
+++ b/brands/BSA/tokens/type.js
@@ -1,5 +1,5 @@
 const systemFont =
-	'-apple-system, BlinkMacSystemFont, "Helvetica Neue", Helvetica, Arial, sans-serif';
+	'-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif';
 
 module.exports = {
 	TYPE: {
@@ -26,8 +26,7 @@ module.exports = {
 		bodyFont: {
 			weights: ['100', '200', '300', '400', '500', '600', '700', '800', '900'],
 			headingWeight: 700,
-			fontFamily:
-				'-apple-system, BlinkMacSystemFont, "Helvetica Neue", Helvetica, Arial, sans-serif',
+			fontFamily: systemFont,
 		},
 		brandFont: {
 			weights: ['300', '300', '300', '300', '300', '300', '700', '700', '700'],

--- a/brands/BTFG/tokens/type.js
+++ b/brands/BTFG/tokens/type.js
@@ -1,11 +1,13 @@
+const systemFont =
+	'-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif';
+
 module.exports = {
 	TYPE: {
 		files: [],
 		bodyFont: {
 			weights: ['100', '200', '300', '400', '500', '600', '700', '800', '900'],
 			headingWeight: 700,
-			fontFamily:
-				'-apple-system, BlinkMacSystemFont, "Helvetica Neue", Helvetica, Arial, sans-serif',
+			fontFamily: systemFont,
 		},
 		brandFont: {
 			weights: ['400', '400', '400', '400', '400', '400', '700', '700', '700'],

--- a/brands/BTFG/tokens/type.js
+++ b/brands/BTFG/tokens/type.js
@@ -1,5 +1,5 @@
 const systemFont =
-	'-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif';
+	'-apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol"';
 
 module.exports = {
 	TYPE: {

--- a/brands/RAMS/tokens/type.js
+++ b/brands/RAMS/tokens/type.js
@@ -1,5 +1,5 @@
 const systemFont =
-	'-apple-system, BlinkMacSystemFont, "Helvetica Neue", Helvetica, Arial, sans-serif';
+	'-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif';
 
 module.exports = {
 	TYPE: {
@@ -35,8 +35,7 @@ module.exports = {
 		bodyFont: {
 			weights: ['100', '200', '300', '400', '500', '600', '700', '800', '900'],
 			headingWeight: 700,
-			fontFamily:
-				'-apple-system, BlinkMacSystemFont, "Helvetica Neue", Helvetica, Arial, sans-serif',
+			fontFamily: systemFont,
 		},
 		brandFont: {
 			weights: ['400', '400', '400', '400', '400', '600', '700', '700', '700'],

--- a/brands/RAMS/tokens/type.js
+++ b/brands/RAMS/tokens/type.js
@@ -1,5 +1,5 @@
 const systemFont =
-	'-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif';
+	'-apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol"';
 
 module.exports = {
 	TYPE: {

--- a/brands/STG/tokens/type.js
+++ b/brands/STG/tokens/type.js
@@ -1,5 +1,5 @@
 const systemFont =
-	'-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif';
+	'-apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol"';
 
 module.exports = {
 	TYPE: {

--- a/brands/STG/tokens/type.js
+++ b/brands/STG/tokens/type.js
@@ -1,5 +1,5 @@
 const systemFont =
-	'-apple-system, BlinkMacSystemFont, "Helvetica Neue", Helvetica, Arial, sans-serif';
+	'-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif';
 
 module.exports = {
 	TYPE: {
@@ -17,8 +17,7 @@ module.exports = {
 		bodyFont: {
 			weights: ['100', '200', '300', '400', '500', '600', '700', '800', '900'],
 			headingWeight: 700,
-			fontFamily:
-				'-apple-system, BlinkMacSystemFont, "Helvetica Neue", Helvetica, Arial, sans-serif',
+			fontFamily: systemFont,
 		},
 		brandFont: {
 			weights: ['400', '400', '400', '400', '400', '400', '400', '400', '400'],

--- a/brands/WBC/tokens/type.js
+++ b/brands/WBC/tokens/type.js
@@ -1,5 +1,5 @@
 const systemFont =
-	'-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif';
+	'-apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol"';
 
 module.exports = {
 	TYPE: {

--- a/brands/WBC/tokens/type.js
+++ b/brands/WBC/tokens/type.js
@@ -1,5 +1,5 @@
 const systemFont =
-	'-apple-system, BlinkMacSystemFont, "Helvetica Neue", Helvetica, Arial, sans-serif';
+	'-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif';
 
 module.exports = {
 	TYPE: {
@@ -17,8 +17,7 @@ module.exports = {
 		bodyFont: {
 			weights: ['100', '200', '300', '400', '500', '600', '700', '800', '900'],
 			headingWeight: 700,
-			fontFamily:
-				'-apple-system, BlinkMacSystemFont, "Helvetica Neue", Helvetica, Arial, sans-serif',
+			fontFamily: systemFont,
 		},
 		brandFont: {
 			weights: ['400', '400', '400', '400', '400', '400', '400', '400', '400'],

--- a/brands/WBG/tokens/type.js
+++ b/brands/WBG/tokens/type.js
@@ -1,5 +1,5 @@
 const systemFont =
-	'-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif';
+	'-apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol"';
 
 module.exports = {
 	TYPE: {

--- a/brands/WBG/tokens/type.js
+++ b/brands/WBG/tokens/type.js
@@ -1,5 +1,5 @@
 const systemFont =
-	'-apple-system, BlinkMacSystemFont, "Helvetica Neue", Helvetica, Arial, sans-serif';
+	'-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif';
 
 module.exports = {
 	TYPE: {
@@ -35,8 +35,7 @@ module.exports = {
 		bodyFont: {
 			weights: ['100', '200', '300', '400', '500', '600', '700', '800', '900'],
 			headingWeight: 700,
-			fontFamily:
-				'-apple-system, BlinkMacSystemFont, "Helvetica Neue", Helvetica, Arial, sans-serif',
+			fontFamily: systemFont,
 		},
 		brandFont: {
 			weights: ['300', '300', '300', '400', '400', '400', '700', '700', '700'],


### PR DESCRIPTION
Rolled back to GEL2 system stack

Propose we consider simplifying (as github did in 2018). `Roboto, Oxygen, Ubuntu, Cantarell, Fira Sans, Droid Sans` no longer specified, and emoji specific fonts listed too. We should probs do this.

https://markdotto.com/2018/02/07/github-system-fonts/#the-stack