### PR TITLE
Dom/404

### DIFF
--- a/website/src/pages/index.js
+++ b/website/src/pages/index.js
@@ -1,0 +1,9 @@
+export default function GEL() {
+	return null;
+}
+
+export const getServerSideProps = async (context) => {
+	const { res } = context;
+	res.writeHead(301, { location: 'https://gel.westpacgroup.com.au' });
+	res.end();
+};


### PR DESCRIPTION
Fixing https://trello.com/c/xjxpm3LV/372-dom-website-next-error-in-staging

The problem was that we did not have an index page and the next framework was trying to fetch that page in participation of someone clicking the link to home. Since we don't actually have the website in the next bundle I just added a 301 forward to the GEL pages SSR to help us and this should actually generate the tiniest bundle for the page which will make the 404 error go away.