### PR TITLE
Selector: tweak type with next indicator

### DIFF
--- a/components/selector/examples/00-examples.js
+++ b/components/selector/examples/00-examples.js
@@ -23,15 +23,15 @@ function Example({ brand }) {
 
 			<h2>Types</h2>
 
-			<h3>Radio</h3>
-			<Selector type="radio" name="example-radio">
-				<Option value="1">Here is a label</Option>
-				<Option value="2">Here is a label</Option>
-				<Option value="3">Here is a label</Option>
+			<h3>Button</h3>
+			<Selector type="button" name="example-button">
+				<Option value="1">Here is button text</Option>
+				<Option value="2">Here is button text</Option>
+				<Option value="3">Here is button text</Option>
 			</Selector>
 
-			<h3>Radio with next indicator</h3>
-			<Selector type="radio" name="example-radio-with-next" nextIndicator>
+			<h3>Radio</h3>
+			<Selector type="radio" name="example-radio">
 				<Option value="1">Here is a label</Option>
 				<Option value="2">Here is a label</Option>
 				<Option value="3">Here is a label</Option>

--- a/components/selector/examples/10-option-hint.js
+++ b/components/selector/examples/10-option-hint.js
@@ -40,19 +40,19 @@ function Example({ brand }) {
 
 			<h2>Short hint</h2>
 
-			<h3>Radio</h3>
-			<Selector type="radio" name="example-radio-hint">
+			<h3>Button</h3>
+			<Selector type="button" name="example-button-hint">
 				<Option value="1" hint="This is some content to go in the product selector thing">
-					Here is a label
+					Here is button text
 				</Option>
 				<Option value="2" hint="This is some content to go in the product selector thing">
-					Here is a label
+					Here is button text
 				</Option>
-				<Option value="3">Here is a label</Option>
+				<Option value="3">Here is button text</Option>
 			</Selector>
 
-			<h3>Radio with next indicator</h3>
-			<Selector type="radio" name="example-radio-hint-with-next" nextIndicator>
+			<h3>Radio</h3>
+			<Selector type="radio" name="example-radio-hint">
 				<Option value="1" hint="This is some content to go in the product selector thing">
 					Here is a label
 				</Option>
@@ -77,25 +77,25 @@ function Example({ brand }) {
 
 			<h2>Long hint</h2>
 
-			<h3>Radio</h3>
-			<Selector type="radio" name="example-radio-hint-long">
+			<h3>Button</h3>
+			<Selector type="button" name="example-button-hint-long">
 				<Option
 					value="1"
 					hint="This is some content to go in the product selector thing which is longer. It's a little longer, actually when I come to think of it, it's quite a bit longer. But not crazy long, just enough length to test this with."
 				>
-					Here is a label
+					Here is button text
 				</Option>
 				<Option
 					value="2"
 					hint="This is some content to go in the product selector thing which is longer. It's a little longer, actually when I come to think of it, it's quite a bit longer. But not crazy long, just enough length to test this with."
 				>
-					Here is a label
+					Here is button text
 				</Option>
-				<Option value="3">Here is a label</Option>
+				<Option value="3">Here is button text</Option>
 			</Selector>
 
-			<h3>Radio with next indicator</h3>
-			<Selector type="radio" name="example-radio-hint-long-with-next" nextIndicator>
+			<h3>Radio</h3>
+			<Selector type="radio" name="example-radio-hint-long">
 				<Option
 					value="1"
 					hint="This is some content to go in the product selector thing which is longer. It's a little longer, actually when I come to think of it, it's quite a bit longer. But not crazy long, just enough length to test this with."
@@ -132,19 +132,19 @@ function Example({ brand }) {
 
 			<h2>Long hint with paragraphs</h2>
 
-			<h3>Radio</h3>
-			<Selector type="radio" name="example-radio-hint-long">
+			<h3>Button</h3>
+			<Selector type="button" name="example-button-hint-long">
 				<Option value="1" hint={hintHTML}>
-					Here is a label
+					Here is button text
 				</Option>
 				<Option value="2" hint={hintHTML}>
-					Here is a label
+					Here is button text
 				</Option>
-				<Option value="3">Here is a label</Option>
+				<Option value="3">Here is button text</Option>
 			</Selector>
 
-			<h3>Radio with next indicator</h3>
-			<Selector type="radio" name="example-radio-hint-long-with-next" nextIndicator>
+			<h3>Radio</h3>
+			<Selector type="radio" name="example-radio-hint-long">
 				<Option value="1" hint={hintHTML}>
 					Here is a label
 				</Option>

--- a/components/selector/examples/20-pictogram.js
+++ b/components/selector/examples/20-pictogram.js
@@ -23,21 +23,21 @@ function Example({ brand }) {
 		<GEL brand={brand}>
 			<h2>Short hint</h2>
 
-			<h3>Radio</h3>
-			<Selector type="radio" name="example-radio-hint">
+			<h3>Button</h3>
+			<Selector type="button" name="example-button-hint">
 				<Option value="1" pictogram={ChatPictogram} hint={hintShort}>
-					Here is a label
+					Here is button text
 				</Option>
 				<Option value="2" pictogram={TruckPictogram}>
-					Here is a label
+					Here is button text
 				</Option>
 				<Option value="3" pictogram={ClockPictogram}>
-					Here is a label
+					Here is button text
 				</Option>
 			</Selector>
 
-			<h3>Radio with next indicator</h3>
-			<Selector type="radio" name="example-radio-hint-with-next" nextIndicator>
+			<h3>Radio</h3>
+			<Selector type="radio" name="example-radio-hint">
 				<Option value="1" pictogram={ChatPictogram} hint={hintShort}>
 					Here is a label
 				</Option>
@@ -66,21 +66,21 @@ function Example({ brand }) {
 
 			<h2>Long hint</h2>
 
-			<h3>Radio</h3>
-			<Selector type="radio" name="example-radio-long">
+			<h3>Button</h3>
+			<Selector type="button" name="example-button-long">
 				<Option value="1" pictogram={ChatPictogram} hint={hintLong}>
-					Here is a label
+					Here is button text
 				</Option>
 				<Option value="2" pictogram={TruckPictogram}>
-					Here is a label
+					Here is button text
 				</Option>
 				<Option value="3" pictogram={ClockPictogram}>
-					Here is a label
+					Here is button text
 				</Option>
 			</Selector>
 
-			<h3>Radio with next indicator</h3>
-			<Selector type="radio" name="example-radio-long-with-next" nextIndicator>
+			<h3>Radio</h3>
+			<Selector type="radio" name="example-radio-long">
 				<Option value="1" pictogram={ChatPictogram} hint={hintLong}>
 					Here is a label
 				</Option>

--- a/components/selector/examples/30-icon.js
+++ b/components/selector/examples/30-icon.js
@@ -23,21 +23,21 @@ function Example({ brand }) {
 		<GEL brand={brand}>
 			<h2>Short hint</h2>
 
-			<h3>Radio</h3>
-			<Selector type="radio" name="example-radio-hint">
+			<h3>Button</h3>
+			<Selector type="button" name="example-button-hint">
 				<Option value="1" icon={AccessibilityIcon} hint={hintShort}>
-					Here is a label
+					Here is button text
 				</Option>
 				<Option value="2" icon={AtmIcon}>
-					Here is a label
+					Here is button text
 				</Option>
 				<Option value="3" icon={CarIcon}>
-					Here is a label
+					Here is button text
 				</Option>
 			</Selector>
 
-			<h3>Radio with next indicator</h3>
-			<Selector type="radio" name="example-radio-hint-with-next" nextIndicator>
+			<h3>Radio</h3>
+			<Selector type="radio" name="example-radio-hint">
 				<Option value="1" icon={AccessibilityIcon} hint={hintShort}>
 					Here is a label
 				</Option>
@@ -66,21 +66,21 @@ function Example({ brand }) {
 
 			<h2>Long hint</h2>
 
-			<h3>Radio</h3>
-			<Selector type="radio" name="example-radio-long">
+			<h3>Button</h3>
+			<Selector type="button" name="example-button-long">
 				<Option value="1" icon={AccessibilityIcon} hint={hintLong}>
-					Here is a label
+					Here is button text
 				</Option>
 				<Option value="2" icon={AtmIcon}>
-					Here is a label
+					Here is button text
 				</Option>
 				<Option value="3" icon={CarIcon}>
-					Here is a label
+					Here is button text
 				</Option>
 			</Selector>
 
-			<h3>Radio with next indicator</h3>
-			<Selector type="radio" name="example-radio-long-with-next" nextIndicator>
+			<h3>Radio</h3>
+			<Selector type="radio" name="example-radio-long">
 				<Option value="1" icon={AccessibilityIcon} hint={hintLong}>
 					Here is a label
 				</Option>

--- a/components/selector/examples/40-secondary-label.js
+++ b/components/selector/examples/40-secondary-label.js
@@ -37,19 +37,19 @@ function Example({ brand }) {
 
 			<h2>Short hint and secondary label</h2>
 
-			<h3>Radio</h3>
-			<Selector type="radio" name="example-radio-short">
+			<h3>Button</h3>
+			<Selector type="button" name="example-button-indicator-short">
 				<Option value="1" hint={hintBankAccount} secondaryLabel={secondLabelShort}>
-					Here is a label
+					Here is button text
 				</Option>
 				<Option value="2" secondaryLabel={secondLabelShort}>
-					Here is a label
+					Here is button text
 				</Option>
-				<Option value="3">Here is a label</Option>
+				<Option value="3">Here is button text</Option>
 			</Selector>
 
-			<h3>Radio with next indicator</h3>
-			<Selector type="radio" name="example-radio-indicator-short" nextIndicator>
+			<h3>Radio</h3>
+			<Selector type="radio" name="example-radio-short">
 				<Option value="1" hint={hintBankAccount} secondaryLabel={secondLabelShort}>
 					Here is a label
 				</Option>
@@ -70,26 +70,26 @@ function Example({ brand }) {
 				<Option value="3">Here is a label</Option>
 			</Selector>
 
-			<h3>Pictogram radio</h3>
-			<Selector type="radio" name="example-radio-pictogram-short">
+			<h3>Pictogram button</h3>
+			<Selector type="button" name="example-button-indicator-pictogram-short">
 				<Option
 					value="1"
 					pictogram={ChatPictogram}
 					hint={hintBankAccount}
 					secondaryLabel={secondLabelShort}
 				>
-					Here is a label
+					Here is button text
 				</Option>
 				<Option value="2" pictogram={TruckPictogram} secondaryLabel={secondLabelShort}>
-					Here is a label
+					Here is button text
 				</Option>
 				<Option value="3" pictogram={ClockPictogram}>
-					Here is a label
+					Here is button text
 				</Option>
 			</Selector>
 
-			<h3>Pictogram radio with next indicator</h3>
-			<Selector type="radio" name="example-radio-indicator-pictogram-short" nextIndicator>
+			<h3>Pictogram radio</h3>
+			<Selector type="radio" name="example-radio-pictogram-short">
 				<Option
 					value="1"
 					pictogram={ChatPictogram}
@@ -124,26 +124,26 @@ function Example({ brand }) {
 				</Option>
 			</Selector>
 
-			<h3>Icon radio</h3>
-			<Selector type="radio" name="example-radio-icon-short">
+			<h3>Icon button</h3>
+			<Selector type="button" name="example-button-indicator-icon-short">
 				<Option
 					value="1"
 					icon={AccessibilityIcon}
 					hint={hintBankAccount}
 					secondaryLabel={secondLabelShort}
 				>
-					Here is a label
+					Here is buton text
 				</Option>
 				<Option value="2" icon={AtmIcon} secondaryLabel={secondLabelShort}>
-					Here is a label
+					Here is buton text
 				</Option>
 				<Option value="3" icon={CarIcon}>
-					Here is a label
+					Here is buton text
 				</Option>
 			</Selector>
 
-			<h3>Icon radio with next indicator</h3>
-			<Selector type="radio" name="example-radio-indicator-icon-short" nextIndicator>
+			<h3>Icon radio</h3>
+			<Selector type="radio" name="example-radio-icon-short">
 				<Option
 					value="1"
 					icon={AccessibilityIcon}
@@ -182,19 +182,19 @@ function Example({ brand }) {
 
 			<h2>Long hint and secondary label</h2>
 
-			<h3>Radio</h3>
-			<Selector type="radio" name="example-radio-long">
+			<h3>Button</h3>
+			<Selector type="button" name="example-button-indicator-long">
 				<Option value="1" hint={hintLong} secondaryLabel={secondLabelLong}>
-					Here is a label
+					Here is button text
 				</Option>
 				<Option value="2" secondaryLabel={secondLabelLong}>
-					Here is a label
+					Here is button text
 				</Option>
-				<Option value="3">Here is a label</Option>
+				<Option value="3">Here is button text</Option>
 			</Selector>
 
-			<h3>Radio with next indicator</h3>
-			<Selector type="radio" name="example-radio-indicator-long" nextIndicator>
+			<h3>Radio</h3>
+			<Selector type="radio" name="example-radio-long">
 				<Option value="1" hint={hintLong} secondaryLabel={secondLabelLong}>
 					Here is a label
 				</Option>
@@ -215,26 +215,26 @@ function Example({ brand }) {
 				<Option value="3">Here is a label</Option>
 			</Selector>
 
-			<h3>Pictogram radio</h3>
-			<Selector type="radio" name="example-radio-pictogram-long">
+			<h3>Pictogram button</h3>
+			<Selector type="button" name="example-button-indicator-pictogram-long">
 				<Option
 					value="1"
 					pictogram={ChatPictogram}
 					hint={hintLong}
 					secondaryLabel={secondLabelLong}
 				>
-					Here is a label
+					Here is button text
 				</Option>
 				<Option value="2" pictogram={TruckPictogram} secondaryLabel={secondLabelLong}>
-					Here is a label
+					Here is button text
 				</Option>
 				<Option value="3" pictogram={ClockPictogram}>
-					Here is a label
+					Here is button text
 				</Option>
 			</Selector>
 
-			<h3>Pictogram radio with next indicator</h3>
-			<Selector type="radio" name="example-radio-indicator-pictogram-long" nextIndicator>
+			<h3>Pictogram radio</h3>
+			<Selector type="radio" name="example-radio-pictogram-long">
 				<Option
 					value="1"
 					pictogram={ChatPictogram}
@@ -269,21 +269,21 @@ function Example({ brand }) {
 				</Option>
 			</Selector>
 
-			<h3>Icon radio</h3>
-			<Selector type="radio" name="example-radio-icon-long">
+			<h3>Icon button</h3>
+			<Selector type="button" name="example-button-indicator-icon-long">
 				<Option value="1" icon={AccessibilityIcon} hint={hintLong} secondaryLabel={secondLabelLong}>
-					Here is a label
+					Here is button text
 				</Option>
 				<Option value="2" icon={AtmIcon} secondaryLabel={secondLabelLong}>
-					Here is a label
+					Here is button text
 				</Option>
 				<Option value="3" icon={CarIcon}>
-					Here is a label
+					Here is button text
 				</Option>
 			</Selector>
 
-			<h3>Icon radio with next indicator</h3>
-			<Selector type="radio" name="example-radio-indicator-icon-long" nextIndicator>
+			<h3>Icon radio</h3>
+			<Selector type="radio" name="example-radio-icon-long">
 				<Option value="1" icon={AccessibilityIcon} hint={hintLong} secondaryLabel={secondLabelLong}>
 					Here is a label
 				</Option>

--- a/components/selector/examples/50-disabled-state.js
+++ b/components/selector/examples/50-disabled-state.js
@@ -8,6 +8,13 @@ function Example({ brand }) {
 		<GEL brand={brand}>
 			<h2>Global disabled</h2>
 
+			<h3>Button</h3>
+			<Selector type="button" name="default-button" disabled>
+				<Option value="1">Option 1</Option>
+				<Option value="2">Option 2</Option>
+				<Option value="3">Option 3</Option>
+			</Selector>
+
 			<h3>Radio</h3>
 			<Selector type="radio" name="default-radio" disabled>
 				<Option value="1">Option 1</Option>
@@ -25,6 +32,14 @@ function Example({ brand }) {
 			<hr />
 
 			<h2>Disabled specific options</h2>
+
+			<h3>Button</h3>
+			<Selector type="button" name="default-button-specific" defaultValue={['2']}>
+				<Option value="1">Option 1</Option>
+				<Option value="2" disabled>
+					Option 2
+				</Option>
+			</Selector>
 
 			<h3>Radio</h3>
 			<Selector type="radio" name="default-radio-specific" defaultValue={['2']}>
@@ -48,6 +63,14 @@ function Example({ brand }) {
 			<h2>Disabled fieldset</h2>
 
 			<fieldset disabled>
+				<h3>Button</h3>
+				<Selector type="button" name="default-button-fieldset" defaultValue={['2']}>
+					<Option value="1">Option 1</Option>
+					<Option value="2" disabled>
+						Option 2
+					</Option>
+				</Selector>
+
 				<h3>Radio</h3>
 				<Selector type="radio" name="default-radio-fieldset" defaultValue={['2']}>
 					<Option value="1">Option 1</Option>

--- a/components/selector/src/Option.js
+++ b/components/selector/src/Option.js
@@ -1,7 +1,7 @@
 /** @jsx jsx */
 
 import { jsx, useBrand, getLabel, overrideReconciler, useInstanceId } from '@westpac/core';
-import { forwardRef } from 'react';
+import { forwardRef, useState } from 'react';
 import PropTypes from 'prop-types';
 
 import { defaultOptionBtn } from './overrides/optionBtn';
@@ -47,7 +47,6 @@ export const Option = forwardRef(
 			instanceId,
 			type = 'radio',
 			name,
-			nextIndicator,
 			iconSize,
 			pictogramWidth,
 			pictogramHeight,
@@ -59,7 +58,6 @@ export const Option = forwardRef(
 			overrides: ctxOverrides,
 			...restCtx
 		} = useSelectorContext();
-
 		const optionId = `${instanceId}-option-${useInstanceId()}`;
 		const hintId = `${optionId}-hint`;
 
@@ -76,6 +74,8 @@ export const Option = forwardRef(
 			Indicator: defaultIndicator,
 		};
 
+		const [isToggled, setIsToggled] = useState(false);
+
 		const componentOverrides = overrides || ctxOverrides;
 		const checked = ctxChecked ? ctxChecked.includes(value) : checkedProp;
 
@@ -85,7 +85,6 @@ export const Option = forwardRef(
 			pictogram,
 			icon,
 			secondaryLabel,
-			nextIndicator,
 			iconSize,
 			pictogramWidth,
 			pictogramHeight,
@@ -97,6 +96,7 @@ export const Option = forwardRef(
 			disabled,
 			hint,
 			hintId,
+			isToggled,
 			overrides: componentOverrides,
 			...rest,
 		};
@@ -122,6 +122,10 @@ export const Option = forwardRef(
 			Indicator: { component: Indicator, styles: indicatorStyles, attributes: indicatorAttributes },
 		} = overrideReconciler(defaultOverrides, tokenOverrides, brandOverrides, componentOverrides);
 
+		const handleBtnClick = () => {
+			setIsToggled((currentValue) => !currentValue);
+		};
+
 		return (
 			<Option
 				className={className}
@@ -144,7 +148,7 @@ export const Option = forwardRef(
 					value={value}
 					checked={checked}
 					disabled={disabled}
-					type={type}
+					type={type === 'button' ? 'hidden' : type}
 					name={name}
 					{...restCtx}
 					{...rest}
@@ -179,7 +183,12 @@ export const Option = forwardRef(
 						},
 					}}
 				/>
-				<OptionBtn state={state} {...optionBtnAttributes(state)} css={optionBtnStyles(state)}>
+				<OptionBtn
+					onClick={handleBtnClick}
+					state={state}
+					{...optionBtnAttributes(state)}
+					css={optionBtnStyles(state)}
+				>
 					{pictogram ? (
 						<Pictogram
 							pictogram={pictogram}
@@ -334,11 +343,6 @@ Option.propTypes = {
 			attributes: PropTypes.func,
 		}),
 		Hint: PropTypes.shape({
-			styles: PropTypes.func,
-			component: PropTypes.elementType,
-			attributes: PropTypes.func,
-		}),
-		NextIndicator: PropTypes.shape({
 			styles: PropTypes.func,
 			component: PropTypes.elementType,
 			attributes: PropTypes.func,

--- a/components/selector/src/Option.js
+++ b/components/selector/src/Option.js
@@ -127,55 +127,57 @@ export const Option = forwardRef(
 				css={optionStyles(state)}
 			>
 				{/* a11y: input not exposed as an override, contains logic required to function */}
-				<input
-					ref={ref}
-					id={optionId}
-					aria-describedby={hint && hintId}
-					onChange={
-						disabled
-							? null
-							: typeof onChange === 'undefined'
-							? null
-							: (event) => onChange(event, value, checked)
-					}
-					value={value}
-					checked={checked}
-					disabled={disabled}
-					type={type === 'button' ? 'hidden' : type}
-					name={name}
-					{...restCtx}
-					{...rest}
-					css={{
-						// Normalize
-						// =========
+				{type !== 'button' ? (
+					<input
+						ref={ref}
+						id={optionId}
+						aria-describedby={hint && hintId}
+						onChange={
+							disabled
+								? null
+								: typeof onChange === 'undefined'
+								? null
+								: (event) => onChange(event, value, checked)
+						}
+						value={value}
+						checked={checked}
+						disabled={disabled}
+						type={type}
+						name={name}
+						{...restCtx}
+						{...rest}
+						css={{
+							// Normalize
+							// =========
 
-						// Remove the margin in Firefox and Safari.
-						// input:
-						margin: 0,
+							// Remove the margin in Firefox and Safari.
+							// input:
+							margin: 0,
 
-						// 1. Add the correct box sizing in IE 10.
-						// 2. Remove the padding in IE 10.
-						// [type='checkbox'], [type='radio']:
-						boxSizing: 'border-box', // 1
-						padding: 0, // 2
-						// =========
+							// 1. Add the correct box sizing in IE 10.
+							// 2. Remove the padding in IE 10.
+							// [type='checkbox'], [type='radio']:
+							boxSizing: 'border-box', // 1
+							padding: 0, // 2
+							// =========
 
-						label: getLabel('selector-option-input'),
-						position: 'absolute',
-						top: 0,
-						left: 0,
-						zIndex: 1,
-						opacity: 0,
-						width: '100%',
-						height: '100%',
-						cursor: 'pointer',
-						appearance: 'none',
-						':disabled, fieldset:disabled &': {
-							cursor: 'default',
-							pointerEvents: 'none',
-						},
-					}}
-				/>
+							label: getLabel('selector-option-input'),
+							position: 'absolute',
+							top: 0,
+							left: 0,
+							zIndex: 1,
+							opacity: 0,
+							width: '100%',
+							height: '100%',
+							cursor: 'pointer',
+							appearance: 'none',
+							':disabled, fieldset:disabled &': {
+								cursor: 'default',
+								pointerEvents: 'none',
+							},
+						}}
+					/>
+				) : undefined}
 				<OptionBtn
 					onClick={
 						type === 'button' && !disabled ? (event) => onChange(event, value, checked) : undefined

--- a/components/selector/src/Option.js
+++ b/components/selector/src/Option.js
@@ -1,7 +1,7 @@
 /** @jsx jsx */
 
 import { jsx, useBrand, getLabel, overrideReconciler, useInstanceId } from '@westpac/core';
-import { forwardRef, useState } from 'react';
+import { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
 import { defaultOptionBtn } from './overrides/optionBtn';
@@ -74,8 +74,6 @@ export const Option = forwardRef(
 			Indicator: defaultIndicator,
 		};
 
-		const [isToggled, setIsToggled] = useState(false);
-
 		const componentOverrides = overrides || ctxOverrides;
 		const checked = ctxChecked ? ctxChecked.includes(value) : checkedProp;
 
@@ -96,7 +94,6 @@ export const Option = forwardRef(
 			disabled,
 			hint,
 			hintId,
-			isToggled,
 			overrides: componentOverrides,
 			...rest,
 		};
@@ -121,10 +118,6 @@ export const Option = forwardRef(
 			Hint: { component: Hint, styles: hintStyles, attributes: hintAttributes },
 			Indicator: { component: Indicator, styles: indicatorStyles, attributes: indicatorAttributes },
 		} = overrideReconciler(defaultOverrides, tokenOverrides, brandOverrides, componentOverrides);
-
-		const handleBtnClick = () => {
-			setIsToggled((currentValue) => !currentValue);
-		};
 
 		return (
 			<Option
@@ -184,7 +177,9 @@ export const Option = forwardRef(
 					}}
 				/>
 				<OptionBtn
-					onClick={handleBtnClick}
+					onClick={
+						type === 'button' && !disabled ? (event) => onChange(event, value, checked) : undefined
+					}
 					state={state}
 					{...optionBtnAttributes(state)}
 					css={optionBtnStyles(state)}

--- a/components/selector/src/Selector.js
+++ b/components/selector/src/Selector.js
@@ -36,7 +36,6 @@ export const Selector = ({
 	type,
 	name,
 	value,
-	nextIndicator,
 	iconSize,
 	pictogramWidth,
 	pictogramHeight,
@@ -92,7 +91,6 @@ export const Selector = ({
 		instanceId,
 		type,
 		name,
-		nextIndicator,
 		iconSize,
 		pictogramWidth,
 		pictogramHeight,
@@ -137,17 +135,12 @@ Selector.propTypes = {
 	/**
 	 * Selector type
 	 */
-	type: PropTypes.oneOf(['radio', 'checkbox']).isRequired,
+	type: PropTypes.oneOf(['radio', 'checkbox', 'button']).isRequired,
 
 	/**
 	 * The Selector input element’s name
 	 */
 	name: PropTypes.string,
-
-	/**
-	 * Use automatic next chevron styling, renders 'ArrowRightIcon' icon
-	 */
-	nextIndicator: PropTypes.bool.isRequired,
 
 	/**
 	 * Pictogram graphic width
@@ -247,17 +240,11 @@ Selector.propTypes = {
 			component: PropTypes.elementType,
 			attributes: PropTypes.func,
 		}),
-		NextIndicator: PropTypes.shape({
-			styles: PropTypes.func,
-			component: PropTypes.elementType,
-			attributes: PropTypes.func,
-		}),
 	}),
 };
 
 export const defaultProps = {
 	type: 'radio',
-	nextIndicator: false,
 	iconSize: 'medium',
 };
 

--- a/components/selector/src/Selector.js
+++ b/components/selector/src/Selector.js
@@ -76,7 +76,7 @@ export const Selector = ({
 	};
 
 	const handleChange = (event, value, wasChecked) => {
-		if (type === 'radio') {
+		if (type === 'radio' || type === 'button') {
 			setChecked(asArray(value));
 		} else {
 			if (wasChecked) {

--- a/components/selector/src/overrides/indicator.js
+++ b/components/selector/src/overrides/indicator.js
@@ -7,8 +7,8 @@ import { ArrowRightIcon } from '@westpac/icon';
 // Component
 // ==============================
 
-const Indicator = ({ state: { type, nextIndicator }, ...rest }) =>
-	type === 'radio' && nextIndicator ? (
+const Indicator = ({ state: { type }, ...rest }) =>
+	type === 'button' ? (
 		<ArrowRightIcon size="medium" assistiveText={null} {...rest} />
 	) : (
 		<div {...rest} />
@@ -18,7 +18,7 @@ const Indicator = ({ state: { type, nextIndicator }, ...rest }) =>
 // Styles
 // ==============================
 
-const indicatorStyles = (_, { type, nextIndicator }) => {
+const indicatorStyles = (_, { type }) => {
 	const { COLORS, SPACING } = useBrand();
 	const mq = useMediaQuery();
 
@@ -29,18 +29,17 @@ const indicatorStyles = (_, { type, nextIndicator }) => {
 		flex: 'none',
 
 		// Next indicator (ArrowNextIcon)
-		...(type === 'radio' &&
-			nextIndicator && {
-				color: COLORS.primary,
-				marginRight: `-${SPACING(1)}`, //tweak
-				transition: 'transform 0.2s ease',
-				'input:hover + div &': {
-					transform: `translateX(${SPACING(1)})`,
-				},
-			}),
+		...(type === 'button' && {
+			color: COLORS.primary,
+			marginRight: `-${SPACING(1)}`, //tweak
+			transition: 'transform 0.2s ease',
+			'button:hover &': {
+				transform: `translateX(${SPACING(1)})`,
+			},
+		}),
 
 		// Check indicator
-		...((type === 'checkbox' || (type === 'radio' && !nextIndicator)) && {
+		...((type === 'checkbox' || type === 'radio') && {
 			display: 'flex',
 			alignItems: 'center',
 			justifyContent: 'center',
@@ -69,7 +68,7 @@ const indicatorStyles = (_, { type, nextIndicator }) => {
 // ==============================
 
 const indicatorAttributes = (_, { type }) => ({
-	'aria-hidden': type === 'radio' ? 'true' : null,
+	'aria-hidden': type === 'button' ? 'true' : null,
 });
 
 // ==============================

--- a/components/selector/src/overrides/label.js
+++ b/components/selector/src/overrides/label.js
@@ -6,7 +6,10 @@ import { jsx, useBrand, getLabel } from '@westpac/core';
 // Component
 // ==============================
 
-const Label = ({ state: _, ...rest }) => <label {...rest} />;
+const Label = ({ state: { type }, ...rest }) => {
+	const Tag = type === 'button' ? 'div' : 'label';
+	return <Tag {...rest} />;
+};
 
 // ==============================
 // Styles
@@ -28,8 +31,8 @@ const labelStyles = () => {
 // Attributes
 // ==============================
 
-const labelAttributes = (_, { optionId }) => ({
-	htmlFor: optionId, //a11y: use explicit association
+const labelAttributes = (_, { type, optionId }) => ({
+	htmlFor: type !== 'button' ? optionId : undefined, //a11y: use explicit association
 });
 
 // ==============================

--- a/components/selector/src/overrides/optionBtn.js
+++ b/components/selector/src/overrides/optionBtn.js
@@ -6,19 +6,61 @@ import { jsx, useMediaQuery, useBrand, getLabel } from '@westpac/core';
 // Component
 // ==============================
 
-const OptionBtn = ({ state: _, ...rest }) => <div {...rest} />;
+const OptionBtn = ({ state: { type }, ...rest }) => {
+	const Tag = type === 'button' ? 'button' : 'div';
+	return <Tag {...rest} />;
+};
 
 // ==============================
 // Styles
 // ==============================
 
-const optionBtnStyles = () => {
+const optionBtnStyles = (_, { type, isToggled }) => {
 	const { PACKS, SPACING, COLORS } = useBrand();
 	const mq = useMediaQuery();
 
 	const paddingArr = [SPACING(3), null, SPACING(4)];
 
 	return mq({
+		// Normalize
+		// ==========
+
+		// 1. Change the font styles in all browsers.
+		// 2. Remove the margin in Firefox and Safari.
+		// button, input, optgroup, select, textarea:
+		...(type === 'button' && {
+			fontFamily: 'inherit', // 1
+			fontSize: '100%', // 1
+			lineHeight: 1.15, // 1
+			margin: 0, // 2
+		}),
+
+		// Show the overflow in IE ('button' and 'input) and Edge ('input').
+		// button, input:
+		...(type === 'button' && {
+			overflow: 'visible',
+		}),
+
+		// Remove the inheritance of text transform in Edge, Firefox, and IE.
+		// button, select:
+		...(type === 'button' && { textTransform: 'none' }),
+
+		// Correct the inability to style clickable types in iOS and Safari.
+		// button, [type='button'], [type='reset'], [type='submit']:
+		...(type === 'button' && {
+			WebkitAppearance: 'button',
+		}),
+
+		// Remove the inner border and padding in Firefox.
+		// button::-moz-focus-inner, [type='button']::-moz-focus-inner, [type='reset']::-moz-focus-inner, [type='submit']::-moz-focus-inner:
+		...(type === 'button' && {
+			'&::-moz-focus-inner': {
+				borderStyle: 'none',
+				padding: 0,
+			},
+		}),
+		// =========
+
 		label: getLabel('selector-option-btn'),
 		display: 'flex',
 		justifyContent: 'space-between',
@@ -31,6 +73,7 @@ const optionBtnStyles = () => {
 		border: `1px solid ${COLORS.borderDark}`,
 		borderRadius: '0.1875rem',
 		padding: paddingArr,
+		backgroundColor: type === 'button' && 'transparent',
 
 		// Hover state
 		'input:hover + &': {
@@ -39,7 +82,7 @@ const optionBtnStyles = () => {
 
 		// Checked state
 		// Note: Padding reduced to counter the increased border width
-		'input:checked + &': {
+		'input:checked + &, &[aria-pressed="true"]': {
 			borderColor: COLORS.hero,
 			borderWidth: '3px',
 			padding: paddingArr.map((p) => p && `calc(${p} - 2px)`),
@@ -62,7 +105,10 @@ const optionBtnStyles = () => {
 // Attributes
 // ==============================
 
-const optionBtnAttributes = () => null;
+const optionBtnAttributes = (_, { type, isToggled }) => ({
+	type: type === 'button' ? 'button' : undefined,
+	'aria-pressed': type === 'button' && isToggled,
+});
 
 // ==============================
 // Exports

--- a/components/selector/src/overrides/optionBtn.js
+++ b/components/selector/src/overrides/optionBtn.js
@@ -15,7 +15,7 @@ const OptionBtn = ({ state: { type }, ...rest }) => {
 // Styles
 // ==============================
 
-const optionBtnStyles = (_, { type }) => {
+const optionBtnStyles = (_, { type, disabled }) => {
 	const { PACKS, SPACING, COLORS } = useBrand();
 	const mq = useMediaQuery();
 
@@ -65,6 +65,7 @@ const optionBtnStyles = (_, { type }) => {
 		display: 'flex',
 		justifyContent: 'space-between',
 		alignItems: 'flex-start',
+		textAlign: 'left',
 		width: '100%',
 		cursor: 'pointer',
 		touchAction: 'manipulation',
@@ -94,6 +95,11 @@ const optionBtnStyles = (_, { type }) => {
 			pointerEvents: 'none',
 		},
 
+		...(disabled && {
+			opacity: '0.5',
+			pointerEvents: 'none',
+		}),
+
 		// Focus state
 		'body:not(.isMouseMode) input:focus + &': {
 			...PACKS.focus,
@@ -105,9 +111,10 @@ const optionBtnStyles = (_, { type }) => {
 // Attributes
 // ==============================
 
-const optionBtnAttributes = (_, { type, checked }) => ({
+const optionBtnAttributes = (_, { type, value, checked }) => ({
 	type: type === 'button' ? 'button' : undefined,
-	'aria-pressed': type === 'button' && checked,
+	'data-value': type === 'button' ? value : undefined,
+	'aria-pressed': type === 'button' ? checked : undefined,
 });
 
 // ==============================

--- a/components/selector/src/overrides/optionBtn.js
+++ b/components/selector/src/overrides/optionBtn.js
@@ -90,15 +90,11 @@ const optionBtnStyles = (_, { type, disabled }) => {
 		},
 
 		// Disabled state
-		'input:disabled + &, fieldset:disabled &': {
+		// Disabled checkbox/radio, disabled button type (hidden input) or disabled fieldset
+		'input:disabled + &, input:disabled ~ div &, fieldset:disabled &': {
 			opacity: '0.5',
 			pointerEvents: 'none',
 		},
-
-		...(disabled && {
-			opacity: '0.5',
-			pointerEvents: 'none',
-		}),
 
 		// Focus state
 		'body:not(.isMouseMode) input:focus + &': {

--- a/components/selector/src/overrides/optionBtn.js
+++ b/components/selector/src/overrides/optionBtn.js
@@ -15,7 +15,7 @@ const OptionBtn = ({ state: { type }, ...rest }) => {
 // Styles
 // ==============================
 
-const optionBtnStyles = (_, { type, isToggled }) => {
+const optionBtnStyles = (_, { type }) => {
 	const { PACKS, SPACING, COLORS } = useBrand();
 	const mq = useMediaQuery();
 
@@ -105,9 +105,9 @@ const optionBtnStyles = (_, { type, isToggled }) => {
 // Attributes
 // ==============================
 
-const optionBtnAttributes = (_, { type, isToggled }) => ({
+const optionBtnAttributes = (_, { type, checked }) => ({
 	type: type === 'button' ? 'button' : undefined,
-	'aria-pressed': type === 'button' && isToggled,
+	'aria-pressed': type === 'button' && checked,
 });
 
 // ==============================

--- a/components/selector/src/overrides/selector.js
+++ b/components/selector/src/overrides/selector.js
@@ -6,7 +6,14 @@ import { jsx, getLabel } from '@westpac/core';
 // Component
 // ==============================
 
-const Selector = ({ state: _, ...rest }) => <div {...rest} />;
+const Selector = ({ state: { type, checked, disabled, name }, children, ...rest }) => (
+	<div {...rest}>
+		{children}
+		{type === 'button' ? (
+			<input type="hidden" value={checked} disabled={disabled} name={name} />
+		) : undefined}
+	</div>
+);
 
 // ==============================
 // Styles

--- a/components/selector/src/overrides/selector.js
+++ b/components/selector/src/overrides/selector.js
@@ -8,10 +8,10 @@ import { jsx, getLabel } from '@westpac/core';
 
 const Selector = ({ state: { type, checked, disabled, name }, children, ...rest }) => (
 	<div {...rest}>
-		{children}
 		{type === 'button' ? (
 			<input type="hidden" value={checked} disabled={disabled} name={name} />
 		) : undefined}
+		{children}
 	</div>
 );
 


### PR DESCRIPTION
Previous attempt didn't work for keyboard users; who select the first option on arrival, and only fire onChange on spacebar press or first arrow down (so wouldn't be able to actually choose anything other than the first or second option, before being taken to the next step/page in the form) 😬

New approach has been implemented as `type="button"` rather than a styling prop (`nextIndicator`). It uses buttons with `aria-pressed` attributes to indicate (a11y) state change. Rather than a separate input for each option, there is one hidden input with dynamic value. 

The button elements have a `data-value` attribute for use in the blender. Some jQuery will take the currently selected button onClick, and set the hidden input value to the button's data-value.