### PR TITLE
Fix mouse mode never turned back on, refactor isMouseMode to focus-visible polyfill-like

### DIFF
--- a/components/button-group/src/overrides/button.js
+++ b/components/button-group/src/overrides/button.js
@@ -74,7 +74,7 @@ const buttonStyles = () => {
 		},
 
 		// Focus state
-		'body:not(.isMouseMode) input:focus + &': {
+		'body.focus-visible input:focus + &': {
 			...PACKS.focus,
 		},
 	})[0];

--- a/components/core/blender/script.js
+++ b/components/core/blender/script.js
@@ -77,27 +77,31 @@ var GEL = (function GELCore() {
 
 				if (!hasScript) {
 					// Insert a script that:
-					// - adds the "isMouseMode" class to the body
+					// - removes the "focus-visible" class to the body if somehow present
 					// - listens for the tab key
-					// - when tab key is pressed removes the "isMouseMode" class and removes the listener
+					// - when tab key is pressed adds the "focus-visible" class and removes the listener
 					var scriptEl = document.createElement('script');
 					scriptEl.setAttribute('id', 'GELFocus');
 					scriptEl.text =
-						'function GELKeyHandler( event ) {' +
-						'	if( event.key === "Tab" ) {' +
-						'		document.getElementsByTagName("body")[ 0 ].classList.remove("isMouseMode");' +
-						'		document.removeEventListener("keydown", GELKeyHandler);' +
+						'function GELKeyHandler(event) {' +
+						'	if (event.key === "Tab") {' +
+						'		document.body.classList.add("focus-visible");' +
 						'	}' +
 						'};' +
 						'' +
-						'document.getElementsByTagName("body")[ 0 ].classList.add("isMouseMode");' +
-						'window.document.addEventListener("keydown", GELKeyHandler);';
+						'function GELClickHandler(event) {' +
+						'	document.body.classList.remove("focus-visible");' +
+						'};' +
+						'' +
+						'document.body.classList.remove("focus-visible");' +
+						'document.addEventListener("keydown", GELKeyHandler);';
+						'document.addEventListener("mousedown", GELClickHandler);';
 					document.body.insertBefore(scriptEl, document.body.firstChild);
 
-					// Insert CSS style to hide all focus only when the "isMouseMode" is present
+					// Insert CSS style to hide all focus only when the "focus-visible" is absent
 					var styleEl = document.createElement('style');
 					styleEl.setAttribute('type', 'text/css');
-					styleEl.innerHTML = '.isMouseMode :focus {' + '	outline: 0 !important;' + '}';
+					styleEl.innerHTML = 'body:not(.focus-visible) :focus {' + '	outline: 0 !important;' + '}';
 					document.head.appendChild(styleEl);
 				}
 			}

--- a/components/core/src/useFocus.js
+++ b/components/core/src/useFocus.js
@@ -5,29 +5,33 @@ export const useFocus = () => {
 
 		if (!hasScript) {
 			// Insert a script that:
-			// - adds the "isMouseMode" class to the body
+			// - removes the "focus-visible" class to the body if somehow present
 			// - listens for the tab key
-			// - when tab key is pressed removes the "isMouseMode" class and removes the listener
+			// - when tab key is pressed adds the "focus-visible" class and removes the listener
 			const scriptEl = document.createElement('script');
 			scriptEl.setAttribute('id', 'GELFocus');
 			scriptEl.text = `
-				function GELKeyHandler( event ) {
-					if( event.key === 'Tab' ) {
-						document.getElementsByTagName('body')[ 0 ].classList.remove('isMouseMode');
-						document.removeEventListener('keydown', GELKeyHandler);
+				function GELKeyHandler(event) {
+					if (event.key === 'Tab') {
+						document.body.classList.add('focus-visible');
 					}
 				};
 
-				document.getElementsByTagName('body')[ 0 ].classList.add('isMouseMode');
-				window.document.addEventListener('keydown', GELKeyHandler);
+				function GELClickHandler(event) {
+					document.body.classList.remove('focus-visible');
+				};
+
+				document.body.classList.remove('focus-visible');
+				document.addEventListener('keydown', GELKeyHandler);
+				document.addEventListener('mousedown', GELClickHandler);
 			`;
 			document.body.insertBefore(scriptEl, document.body.firstChild);
 
-			// Insert CSS style to hide all focus only when the "isMouseMode" is present
+			// Insert CSS style to hide all focus only when the "focus-visible" is absent
 			const styleEl = document.createElement('style');
 			styleEl.setAttribute('type', 'text/css');
 			styleEl.innerHTML = `
-				.isMouseMode :focus {
+				body:not(.focus-visible) :focus {
 					outline: 0 !important;
 				}
 			`;

--- a/components/form-check/src/overrides/label.js
+++ b/components/form-check/src/overrides/label.js
@@ -71,7 +71,7 @@ const labelStyles = (_, { type, size }) => {
 			borderRadius: type === 'radio' ? '50%' : 3,
 
 			// Focus state
-			'body:not(.isMouseMode) input:focus + &': {
+			'body.focus-visible input:focus + &': {
 				...PACKS.focus,
 			},
 

--- a/components/selector/src/overrides/optionBtn.js
+++ b/components/selector/src/overrides/optionBtn.js
@@ -126,7 +126,7 @@ const optionBtnStyles = () => {
 		},
 
 		// Focus state
-		'body:not(.isMouseMode) input:focus + &': {
+		'body.focus-visible input:focus + &': {
 			...PACKS.focus,
 		},
 	})[0];

--- a/components/switch/src/overrides/toggle.js
+++ b/components/switch/src/overrides/toggle.js
@@ -88,7 +88,7 @@ const toggleStyles = (_, { size }) => {
 			cursor: 'not-allowed',
 		},
 
-		'body:not(.isMouseMode) input:focus ~ &': {
+		'body.focus-visible input:focus ~ &': {
 			...PACKS.focus,
 		},
 	})[0];


### PR DESCRIPTION
Fixes #779.

https://user-images.githubusercontent.com/5426427/128701591-10b29901-f49a-4ab3-923f-4d0b8aa9bf9e.mov

(with sound - you can hear me clicking mouse and hitting keyboard buttons)

**What this PR does**

Replaces `.isMouseMode` with `.focus-visible` class which is a REVERSE of the former and is in line with WICG focus-visible polyfill.

Adjusts all styles that used `.isMouseMode` to use `.focus-visible` instead.

This makes it incredibly simple to ditch `useFocus` in favor of WICG focus-visible polyfill, with no additional changes to styles.

Adds `GELClickHandler` that does the reverse of GELKeyHandler: toggles back mouse mode (i.e. removes `.focus-visible` class). Consequently, ditches the automatic removal of `GELKeyHandler` listener after one invocation, since it needs to be invoked multiple times now

**Concerns:**

| Description | Mitigation |
| --- | --- |
| If page includes popular WICG focus-visible polyfill on its own, the scripts would be both handling `.focus-visible` class name. WICG's version could be less aggresive with adding `.focus-visible` class as it does additional heuristics. | `.gel-focus-visible` class name can be used for now until (and if) we switch to WICG focus-polyfill |

