### PR TITLE
Fix crash on GELjson command if empty directories are present in `components` directory

### DIFF
--- a/helpers/ds-info.js
+++ b/helpers/ds-info.js
@@ -24,9 +24,13 @@ for (const component of components) {
 	i++;
 	process.stdout.write(`\x1b[2K\x1b[0G${i}/${total}`);
 	if (component.isDirectory()) {
-		const pkg = require(path.normalize(
+		const pkgJsonPath = path.normalize(
 			`${__dirname}/../components/${component.name}/package.json`
-		));
+		);
+		if (!fs.existsSync(pkgJsonPath)) {
+			return;
+		}
+		const pkg = require(pkgJsonPath);
 		GEL.components[component.name] = {
 			name: pkg.name,
 			version: pkg.version,


### PR DESCRIPTION
When you switch branches (e.g. from branch introducing header and footer back to develop), Git may not remove directories that were created on the branch you're leaving. This crashes GELjson command as it only looks for directories in `components` directory, and assumes `package.json` will be there. Consequently, with empty folders present in `components` directory you're unable to install GEL repository.