### PR TITLE
Fix duplicated ResizeObserver polyfills

### DIFF
--- a/components/tabcordion/package.json
+++ b/components/tabcordion/package.json
@@ -54,14 +54,14 @@
 	"module": "dist/westpac-tabcordion.esm.js",
 	"dependencies": {
 		"@babel/runtime": "^7.14.8",
-		"@juggle/resize-observer": "^3.3.1",
 		"@westpac/body": "^1.4.0",
 		"@westpac/core": "^2.1.0",
 		"@westpac/hooks": "^2.0.0",
 		"@westpac/icon": "^1.3.2",
 		"bezier-easing": "^2.1.0",
 		"prop-types": "^15.7.2",
-		"react-use-measure": "^2.0.4"
+		"react-use-measure": "^2.0.4",
+		"resize-observer-polyfill": "^1.5.1"
 	},
 	"peerDependencies": {
 		"react": "^17.0.2",

--- a/components/tabcordion/src/overrides/panelBody.js
+++ b/components/tabcordion/src/overrides/panelBody.js
@@ -1,7 +1,7 @@
 /** @jsx jsx */
 
 import { jsx, getLabel, formatClassName } from '@westpac/core';
-import { ResizeObserver } from '@juggle/resize-observer';
+import ResizeObserver from 'resize-observer-polyfill';
 import { useSpring, animated } from 'react-spring';
 import useMeasure from 'react-use-measure';
 import { Body } from '@westpac/body';

--- a/yarn.lock
+++ b/yarn.lock
@@ -2784,11 +2784,6 @@
   resolved "https://registry.yarnpkg.com/@josephg/resolvable/-/resolvable-1.0.1.tgz#69bc4db754d79e1a2f17a650d3466e038d94a5eb"
   integrity sha512-CtzORUwWTTOTqfVtHaKRJ0I1kNQd1bpn3sUh8I3nJDVY+5/M/Oe1DnEWzPQvqq/xPIIkzzzIP7mfCoAjFRvDhg==
 
-"@juggle/resize-observer@^3.3.1":
-  version "3.3.1"
-  resolved "https://registry.yarnpkg.com/@juggle/resize-observer/-/resize-observer-3.3.1.tgz#b50a781709c81e10701004214340f25475a171a0"
-  integrity sha512-zMM9Ds+SawiUkakS7y94Ymqx+S0ORzpG3frZirN3l+UlXUmSUR7hF4wxCVqW+ei94JzV5kt0uXBcoOEAuiydrw==
-
 "@keystonejs/access-control@^5.2.0":
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/@keystonejs/access-control/-/access-control-5.2.0.tgz#4ec79bd6105f1c8992690e8042a141aef1886347"


### PR DESCRIPTION
Fixes #792

Components other than Tabcordion, as well as secondary dependencies of GEL, use `resize-observer-polyfill`. Tabcordion uses `@juggle/resize-observer`. Consequently, installing GEL resulted in two polyfills for the same feature included in the bundle.