### PR TITLE
Replace classnames with clsx 

### DIFF
--- a/components/core/package.json
+++ b/components/core/package.json
@@ -63,7 +63,7 @@
 		"@babel/runtime": "^7.14.8",
 		"@emotion/react": "^11.4.0",
 		"@emotion/weak-memoize": "^0.2.5",
-		"classnames": "^2.3.1",
+		"clsx": "^1.1.1",
 		"color": "^4.0.0",
 		"facepaint": "^1.2.1",
 		"lodash.get": "^4.4.2",

--- a/components/core/src/index.js
+++ b/components/core/src/index.js
@@ -13,5 +13,5 @@ export { useFonts } from './useFonts';
 export { asArray } from './asArray';
 export { GEL } from './GEL';
 
-import classNames from 'classnames';
+import classNames from 'clsx';
 export { classNames };

--- a/yarn.lock
+++ b/yarn.lock
@@ -7013,7 +7013,7 @@ classnames@2.2.6:
   resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.2.6.tgz#43935bffdd291f326dad0a205309b38d00f650ce"
   integrity sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q==
 
-classnames@^2.2.5, classnames@^2.3.1:
+classnames@^2.2.5:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.3.1.tgz#dfcfa3891e306ec1dad105d0e88f4417b8535e8e"
   integrity sha512-OlQdbZ7gLfGarSqxesMesDa5uz7KFbID8Kpq/SxIoNGDqY8lSYs0D+hhtBXhcdB3rcbXArFr7vlHheLk1voeNA==
@@ -7143,7 +7143,7 @@ cloudinary@^1.21.0:
     lodash "^4.17.11"
     q "^1.5.1"
 
-clsx@^1.0.4:
+clsx@^1.0.4, clsx@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/clsx/-/clsx-1.1.1.tgz#98b3134f9abbdf23b2663491ace13c5c03a73188"
   integrity sha512-6/bPho624p3S2pMyvP5kKBPXnI3ufHLObBFCfgx+LkeR5lg2XYy2hqZqUf45ypD8COn2bhgGJSUE+l5dhNBieA==


### PR DESCRIPTION
classnames is not used directly in @westpac/progress-rope - we're using classNames from @westpac/core

Closes #795