### PR TITLE
Add missing role="dialog" to `@westpac/modal`

### DIFF
--- a/components/modal/src/overrides/modal.js
+++ b/components/modal/src/overrides/modal.js
@@ -101,6 +101,7 @@ const blenderStyles = (_, { open, size }) => {
 const modalAttributes = (_, { open }) => ({
 	'aria-modal': 'true',
 	'aria-hidden': !open,
+	'role': 'dialog',
 });
 
 const blenderAttributes = (_, { open, size }) => ({


### PR DESCRIPTION
Fixes #852 

See also: https://www.w3.org/TR/wai-aria-practices-1.1/examples/dialog-modal/dialog.html