### PR TITLE
Server render article pages instead

### DIFF
--- a/website-backend/keystone.ts
+++ b/website-backend/keystone.ts
@@ -46,13 +46,16 @@ export default withAuth(
 				}
 			},
 		},
-		images: {
-			upload: 'local',
-			local: {
-				storagePath: 'public/images',
-				baseUrl: '/images',
-			},
-		},
+		// This config needs to be upgraded as part of keystone upgrade
+		// but I noticed that we're not using local images
+		// so I'm removing this config completely
+		// images: {
+		// 	upload: 'local',
+		// 	local: {
+		// 		storagePath: 'public/images',
+		// 		baseUrl: '/images',
+		// 	},
+		// },
 		ui: {
 			isAccessAllowed: (context: Context) => !!context.session?.data,
 		},

--- a/website/src/pages/articles/index.js
+++ b/website/src/pages/articles/index.js
@@ -41,10 +41,12 @@ const Home = ({ content }) => {
 	);
 };
 
-export async function getStaticProps() {
+export async function getServerSideProps({ req, res }) {
+	res.setHeader('Cache-Control', 'public, s-maxage=10, stale-while-revalidate=59');
+
 	const client = getApolloClient();
 
-	const res = await client.query({
+	const queryRes = await client.query({
 		query: gql`
 			query article($url: String!) {
 				articles(where: { url: { equals: $url } }) {
@@ -60,13 +62,12 @@ export async function getStaticProps() {
 		},
 	});
 
-	const homeArticle = res?.data?.articles[0] || null;
+	const homeArticle = queryRes?.data?.articles[0] || null;
 	const content = homeArticle?.content || null;
 	return {
 		props: {
 			content,
 		},
-		revalidate: 10,
 	};
 }
 


### PR DESCRIPTION
Current build process does not support fetching API data during the build since frontend and API builds are not sequential. This pull request switches the approach from statically building article pages to server rendering the pages where we fetch article home and article page data during server rendering.