### PR TITLE
Increase nginx file upload size limit

### DIFF
--- a/nginx/gel3-keystone-routes.conf
+++ b/nginx/gel3-keystone-routes.conf
@@ -89,6 +89,9 @@ location /api/graphql {
 	proxy_connect_timeout   5;
 	proxy_read_timeout      30;
 
+	# File upload size limit 10MB
+	client_max_body_size 10M;
+
 	# Put server in maintenance mode if page exists
 	if (-f $document_root/construction.html) {
 		return 503;


### PR DESCRIPTION
Default nginx file upload limit is 1Mb. Some of the image files being uploaded for article pages are >1MB in size and we need to support that.

Changes:

- Increase nginx file upload size limit