### PR TITLE
Hotfix/no ref/unit tests autocomplete

### DIFF
--- a/components/autocomplete/examples/00-default.js
+++ b/components/autocomplete/examples/00-default.js
@@ -18,8 +18,10 @@ function Example({ brand }) {
 
 	return (
 		<GEL brand={brand}>
-			<h2>Default</h2>
-			<Autocomplete options={options} />
+			<div data-cy="valid-autocomplete">
+				<h2>Default</h2>
+				<Autocomplete options={options} />
+			</div>
 			<h2>Controlled</h2>
 			<Autocomplete options={options} value={option} onChange={handleChange} />
 			<div data-cy="invalid-autocomplete">

--- a/components/autocomplete/tests/integration/autocomplete.cypress.js
+++ b/components/autocomplete/tests/integration/autocomplete.cypress.js
@@ -5,9 +5,21 @@ describe('Autocomplete', () => {
 	before(() => {
 		defaultPage.visit();
 	});
-	it('should contain a red border when there is a prop invalid', () => {
+
+	it('should have a different colored border than normal color when prop is invalid', () => {
 		defaultPage.invalidAutocomplete
 			.find('[class$="Control"]')
-			.should('have.css', 'border', '1px solid rgb(196, 0, 0)');
+			.invoke('css', 'borderColor')
+			.then(($invalidColor) => {
+				defaultPage.validAutocomplete
+					.find('[class$="Control"]')
+					.invoke('css', 'borderColor')
+					.should('not.eq', $invalidColor)
+					.then(($validColor) => {
+						cy.log("Invalid color = " + $invalidColor)
+						cy.log("Valid color = " + $validColor)
+					});
+			});
 	});
+
 });

--- a/components/autocomplete/tests/integration/autocomplete.cypress.js
+++ b/components/autocomplete/tests/integration/autocomplete.cypress.js
@@ -16,10 +16,9 @@ describe('Autocomplete', () => {
 					.invoke('css', 'borderColor')
 					.should('not.eq', $invalidColor)
 					.then(($validColor) => {
-						cy.log("Invalid color = " + $invalidColor)
-						cy.log("Valid color = " + $validColor)
+						cy.log('Invalid color = ' + $invalidColor);
+						cy.log('Valid color = ' + $validColor);
 					});
 			});
 	});
-
 });

--- a/components/autocomplete/tests/pages/default.page.ts
+++ b/components/autocomplete/tests/pages/default.page.ts
@@ -9,6 +9,9 @@ class DefaultPage extends CommonPage {
 	get invalidAutocomplete() {
 		return cy.get('[data-cy="invalid-autocomplete"]');
 	}
+	get validAutocomplete() {
+		return cy.get('[data-cy="valid-autocomplete"]');
+	}
 }
 
 export default DefaultPage;


### PR DESCRIPTION
Removed direct test of red border color around the Autocomplete component when invalid prop is applied and replaced with comparison between the css borderColor styles of the Autocomplete when it's invalid and when it's in "normal valid" state respectively.