### PR TITLE
chore: create unit & cypress tests for 3 components in text-input pac…

### DIFF
--- a/components/button-group/tests/unit/button-group.spec.js
+++ b/components/button-group/tests/unit/button-group.spec.js
@@ -43,7 +43,7 @@ const HelperComponent = function () {
 				name="example-custom-key"
 				value={value}
 				onChange={(e, v) => {
-					console.log(`custom-key: ${v}`);
+					// console.log(`custom-key: ${v}`);
 					setValue(v);
 				}}
 			>
@@ -109,12 +109,10 @@ describe('ButtonGroup component', () => {
 		const backgroundColorBeforeClick = window
 			.getComputedStyle(outerSpan)
 			.getPropertyValue('background-color');
-		console.log(backgroundColorBeforeClick);
 		fireEvent.click(outerSpan);
 
 		const styles = window.getComputedStyle(outerSpan);
 		const backgroundColorAfterClick = styles['background-color'];
-		console.log(backgroundColorAfterClick);
 		expect(styles['background-color']).toEqual(styles.backgroundColor);
 		expect(backgroundColorAfterClick).not.toEqual(backgroundColorBeforeClick);
 	});

--- a/components/text-input/examples/00-text-input.js
+++ b/components/text-input/examples/00-text-input.js
@@ -14,7 +14,7 @@ function Example({ brand }) {
 	return (
 		<GEL brand={brand}>
 			<h2>Default</h2>
-			<TextInput />
+			<TextInput data-testid="first-text-input-node" data-cy="default-text-input" />
 
 			<hr />
 
@@ -37,7 +37,7 @@ function Example({ brand }) {
 			<hr />
 
 			<h2>Invalid</h2>
-			<TextInput invalid />
+			<TextInput data-cy="invalid-text-input" invalid />
 
 			<hr />
 

--- a/components/text-input/examples/20-textarea.js
+++ b/components/text-input/examples/20-textarea.js
@@ -16,7 +16,7 @@ function Example({ brand }) {
 	return (
 		<GEL brand={brand}>
 			<h2>Default</h2>
-			<Textarea />
+			<Textarea data-cy="default-textarea" />
 
 			<hr />
 
@@ -39,7 +39,7 @@ function Example({ brand }) {
 			<hr />
 
 			<h2>Invalid</h2>
-			<Textarea placeholder="invalid" invalid />
+			<Textarea data-cy="invalid-textarea" placeholder="invalid" invalid />
 
 			<hr />
 

--- a/components/text-input/tests/integration/text-input.cypress.js
+++ b/components/text-input/tests/integration/text-input.cypress.js
@@ -1,5 +1,26 @@
+import TextInputPage from '../pages/text-input.page';
+
 describe('text-input', () => {
-	before(() => {
-		cy.visit(`http://localhost:8080/`);
+	const textInputPage = new TextInputPage();
+
+	it('should change its content when text-input change event is triggered and handleChange handler is invoked', () => {
+		textInputPage.visit();
+		textInputPage.defaultInputText.then(($targetElement) => {
+			const newVal = ' hello new text value';
+			const expectedVal = $targetElement.val() + newVal;
+			cy.wrap($targetElement).type(newVal).should('have.value', expectedVal);
+		});
+	});
+
+	it('should have a different colored border than normal color when prop is invalid', () => {
+		textInputPage.defaultInputText.invoke('css', 'borderColor').then(($validColor) => {
+			textInputPage.invalidInputText
+				.invoke('css', 'borderColor')
+				.should('not.eq', $validColor)
+				.then(($invalidColor) => {
+					cy.log('Invalid color = ' + $invalidColor);
+					cy.log('Valid color = ' + $validColor);
+				});
+		});
 	});
 });

--- a/components/text-input/tests/integration/textarea.cypress.js
+++ b/components/text-input/tests/integration/textarea.cypress.js
@@ -1,0 +1,57 @@
+import TextAreaPage from '../pages/textarea.page';
+
+describe('textarea', () => {
+	const textareaPage = new TextAreaPage();
+
+	it('should change its content when text-input change event is triggered and handleChange handler is invoked', () => {
+		textareaPage.visit();
+		textareaPage.defaultTextArea.type('Hello');
+		textareaPage.defaultTextArea.should('have.value', 'Hello');
+	});
+
+	it('should have a different colored border than normal color when prop is invalid', () => {
+		textareaPage.visit();
+		textareaPage.defaultTextArea.invoke('css', 'borderColor').then(($validColor) => {
+			textareaPage.invalidTextArea
+				.invoke('css', 'borderColor')
+				.should('not.eq', $validColor)
+				.then(($invalidColor) => {
+					cy.log('Invalid color = ' + $invalidColor);
+					cy.log('Valid color = ' + $validColor);
+				});
+		});
+	});
+
+	it('should change size when made to change size', () => {
+		textareaPage.visit();
+		textareaPage.defaultTextArea.invoke('width').then((origWidth) => {
+			textareaPage.defaultTextArea.invoke('height').then((origHeight) => {
+				cy.log('Original width = ' + origWidth);
+				cy.log('Original height = ' + origHeight);
+				textareaPage.defaultTextArea
+					.invoke('width', 0.5 * origWidth)
+					.invoke('width')
+					.should('be.lt', origWidth)
+					.then(() => {
+						textareaPage.defaultTextArea
+							.invoke('height', 2 * origHeight)
+							.invoke('height')
+							.should('be.gt', origHeight);
+					});
+			});
+		});
+	});
+
+	it('should aquire a scroll bar and be scrollable when necessary', () => {
+		let paragraph1 =
+			'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.\n\n';
+		let paragraph2 =
+			'Sunt ad minim tempor ipsum ad occaecat est incididunt commodo mollit dolor excepteur. Incididunt exercitation incididunt aute amet fugiat sit quis cillum eiusmod aute laboris eiusmod esse officia. Proident dolor eu mollit sint commodo incididunt aliqua velit ipsum duis ullamco. Adipisicing sunt labore eiusmod mollit elit nisi nulla qui quis reprehenderit. Eu laboris exercitation sit velit non cillum. Aute ad deserunt ullamco fugiat laboris est. Ad dolor adipisicing nisi dolor.\n\n';
+		let paragraph3 =
+			'Voluptate aliquip ullamco irure Lorem ad velit mollit ullamco officia quis. Voluptate sunt fugiat labore voluptate velit. Mollit ut irure labore sunt nulla dolore anim id voluptate. Ut sunt aliquip qui amet. Ut proident proident laboris dolor quis irure veniam ea ea ad ut dolor ullamco. Tempor non pariatur ullamco ex ad id ipsum eiusmod consectetur sunt est. Est voluptate esse nulla occaecat ea cillum eu qui voluptate laborum.';
+		let textValue = paragraph1 + paragraph2 + paragraph3;
+		textareaPage.defaultTextArea.invoke('val', textValue);
+		// The test would fail on the next line with an Error if there is no scroll bar.
+		textareaPage.defaultTextArea.scrollTo('bottom', { ensureScrollable: true });
+	});
+});

--- a/components/text-input/tests/pages/common.page.ts
+++ b/components/text-input/tests/pages/common.page.ts
@@ -1,0 +1,17 @@
+/// <reference types="cypress" />
+/* eslint-disable */
+
+class CommonPage {
+	url;
+	constructor(url: string) {
+		this.url = url;
+	}
+	open() {
+		cy.viewport(1200, 1000);
+	}
+	visit() {
+		cy.visit(this.url);
+	}
+}
+
+export default CommonPage;

--- a/components/text-input/tests/pages/text-input.page.ts
+++ b/components/text-input/tests/pages/text-input.page.ts
@@ -1,0 +1,20 @@
+/// <reference types="cypress" />
+
+import CommonPage from './common.page';
+
+/* eslint-disable */
+
+class TextInputPage extends CommonPage {
+	constructor() {
+		super('http://localhost:8080/text-input/text-input');
+	}
+	get defaultInputText() {
+		return cy.get('[data-cy="default-text-input"]');
+	}
+
+	get invalidInputText() {
+		return cy.get('[data-cy="invalid-text-input"]');
+	}
+}
+
+export default TextInputPage;

--- a/components/text-input/tests/pages/textarea.page.ts
+++ b/components/text-input/tests/pages/textarea.page.ts
@@ -1,0 +1,20 @@
+/// <reference types="cypress" />
+
+import CommonPage from './common.page';
+
+/* eslint-disable */
+
+class TextAreaPage extends CommonPage {
+	constructor() {
+		super('http://localhost:8080/text-input/textarea');
+	}
+	get defaultTextArea() {
+		return cy.get('[data-cy="default-textarea"]');
+	}
+
+	get invalidTextArea() {
+		return cy.get('[data-cy="invalid-textarea"]');
+	}
+}
+
+export default TextAreaPage;

--- a/components/text-input/tests/unit/text-input-with-button.spec.js
+++ b/components/text-input/tests/unit/text-input-with-button.spec.js
@@ -1,0 +1,44 @@
+import { GEL } from '@westpac/core';
+import { render } from '@testing-library/react';
+import { screen } from '@testing-library/dom';
+import userEvent from '@testing-library/user-event';
+import { TextInputWithButton } from '@westpac/text-input';
+import { UmbrellaIcon } from '@westpac/icon';
+import { overridesTest } from '../../../../helpers/tests/overrides-test.js';
+import { nestingTest } from '../../../../helpers/tests/nesting-test.js';
+import wbc from '@westpac/wbc';
+
+// The default tests every component should run
+overridesTest({
+	name: 'text-input', // the name has to be the package name without '@westpac/' scope
+	overrides: ['TextInputWithButton'], // every single override root key
+	Component: (props) => (
+		<TextInputWithButton btnIcon={UmbrellaIcon} {...props}>
+			{props.children}
+		</TextInputWithButton>
+	),
+});
+
+// another default test to check that the component errors when outside of GEL and renders when inside
+nestingTest({
+	name: 'text-input-with-button',
+	Component: (props) => <TextInputWithButton {...props} defaultValue={props.children} />,
+});
+
+describe('TextInputWithButton component', () => {
+	const SimpleTextInputWithButton = (props) => (
+		<GEL brand={wbc}>
+			<TextInputWithButton {...props} btnIcon={UmbrellaIcon} />
+		</GEL>
+	);
+
+	test('should show an icon along side the input', () => {
+		render(<SimpleTextInputWithButton />);
+		const theInputElement = screen.getByRole('textbox');
+		const parentElement = theInputElement.parentElement;
+		const theButtonElement = screen.getByRole('button');
+		expect(parentElement.childElementCount).toBe(2);
+		expect(parentElement.firstChild).toBe(theInputElement);
+		expect(parentElement.lastChild).toBe(theButtonElement);
+	});
+});

--- a/components/text-input/tests/unit/text-input.spec.js
+++ b/components/text-input/tests/unit/text-input.spec.js
@@ -1,18 +1,74 @@
 import { GEL } from '@westpac/core';
-import { render } from '@testing-library/react';
+import { fireEvent, render } from '@testing-library/react';
+import { screen } from '@testing-library/dom';
+import userEvent from '@testing-library/user-event';
 import { TextInput } from '@westpac/text-input';
+import { overridesTest } from '../../../../helpers/tests/overrides-test.js';
+import { nestingTest } from '../../../../helpers/tests/nesting-test.js';
 import wbc from '@westpac/wbc';
+
+// The default tests every component should run
+overridesTest({
+	name: 'text-input', // the name has to be the package name without '@westpac/' scope
+	overrides: ['TextInput'], // every single override root key
+	Component: (props) => <TextInput {...props}>{props.children}</TextInput>,
+});
+
+// another default test to check that the component errors when outside of GEL and renders when inside
+nestingTest({
+	name: 'text-input',
+	Component: (props) => <TextInput {...props} defaultValue={props.children} />,
+});
 
 // Component specific tests
 describe('TextInput component', () => {
-	const SimpleTextInput = () => (
+	const SimpleTextInput = (props) => (
 		<GEL brand={wbc}>
-			<TextInput defaultValue="sample" onChange={() => {}} />
+			<TextInput {...props} defaultValue={'sample'} onChange={() => {}} />
 		</GEL>
 	);
 
-	test('It should render TextInput', () => {
-		const { container } = render(<SimpleTextInput />);
-		expect(container).toBeInTheDocument();
+	test('should render text as provided to the TextInput', () => {
+		render(<SimpleTextInput />);
+		const inputNode = screen.getByDisplayValue('sample');
+		expect(inputNode).toHaveValue('sample');
+		fireEvent.change(inputNode, { target: { value: 'modified' } });
+		expect(inputNode.value).toEqual('modified');
+	});
+
+	test('should render additional text typed into TextInput', async () => {
+		render(<SimpleTextInput />);
+		const inputNode = screen.getByRole('textbox');
+		expect(inputNode).toBeInTheDocument();
+		const user = userEvent.setup();
+		await user.type(inputNode, ' modified');
+		expect(inputNode.value).toEqual('sample modified');
+	});
+
+	test('should be disabled when disabled attribute provided', () => {
+		render(<SimpleTextInput disabled />);
+		const inputNode = screen.getByDisplayValue('sample');
+		expect(inputNode).toBeDisabled();
+	});
+
+	test('should not allow any text to be input when disabled', async () => {
+		render(<SimpleTextInput disabled />);
+		const inputNode = screen.getByRole('textbox');
+		expect(inputNode.value).toEqual('sample');
+		const user = userEvent.setup();
+		await user.type(inputNode, 'modified');
+		expect(inputNode.value).toEqual('sample');
+	});
+
+	test('should allow existing text to be deleted', async () => {
+		render(<SimpleTextInput />);
+		const inputNode = screen.getByDisplayValue('sample');
+		expect(inputNode).toBeInTheDocument();
+		expect(inputNode.value).toEqual('sample');
+		expect(inputNode.className).toEqual('css-4t3uc7-textInput');
+		const user = userEvent.setup();
+		await user.tripleClick(inputNode);
+		await user.keyboard('{backspace}');
+		expect(inputNode.value).toEqual('');
 	});
 });

--- a/components/text-input/tsconfig.json
+++ b/components/text-input/tsconfig.json
@@ -14,7 +14,7 @@
 		"resolveJsonModule": true,
 		"isolatedModules": true,
 		"noEmit": true,
-		"jsx": "react-jsx",
+		"jsx": "react",
 		"types": ["@emotion/core"]
 	},
 	"exclude": ["**/dist", "**/node_modules"]

--- a/helpers/tests/nesting-test.js
+++ b/helpers/tests/nesting-test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 
 import { ErrorBoundary } from './error-boundary.js';
 import { GEL } from '@westpac/core';
@@ -17,32 +17,30 @@ function nestingTest({ name, Component }) {
 		});
 
 		test('Errors when the component is rendered outside of <GEL/>', () => {
-			const text = 'Our alert content';
-			const Wrapper = () => <Component>{text}</Component>;
+			const Wrapper = () => <Component />;
 
-			const { container } = render(<Wrapper />, { wrapper: ErrorBoundary });
-
-			expect(container).toHaveTextContent(
-				/GEL components require that you wrap your application with the <GEL \/> brand provider from @westpac\/core./i
-			);
-			expect(() => container.render()).toThrow();
+			render(<Wrapper />, { wrapper: ErrorBoundary });
+			expect(
+				screen.queryByText(
+					/GEL components require that you wrap your application with the <GEL \/> brand provider from @westpac\/core./i
+				)
+			).toBeInTheDocument();
 		});
 
 		test('Renders when the component is rendered inside of <GEL/>', () => {
-			const text = 'Our alert content';
 			const Wrapper = () => (
 				<GEL brand={wbc}>
-					<Component>{text}</Component>
+					<Component />
 				</GEL>
 			);
 
-			const { container } = render(<Wrapper />, { wrapper: ErrorBoundary });
-
-			expect(container).not.toHaveTextContent(
-				/GEL components require that you wrap your application with the <GEL \/> brand provider from @westpac\/core./i
-			);
+			render(<Wrapper />, { wrapper: ErrorBoundary });
+			expect(
+				screen.queryByText(
+					/GEL components require that you wrap your application with the <GEL \/> brand provider from @westpac\/core./i
+				)
+			).toBeNull();
 			expect(console.error).toHaveBeenCalledTimes(0);
-			expect(container).toHaveTextContent(text);
 		});
 	});
 }

--- a/package.json
+++ b/package.json
@@ -106,6 +106,7 @@
     "@react-spring/web": "^9.2.4",
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^13.4.0",
+    "@testing-library/user-event": "^14.4.3",
     "@types/prop-types": "^15.7.5",
     "babel-core": "^7.0.0-bridge.0",
     "babel-jest": "^27.0.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4756,6 +4756,11 @@
     "@testing-library/dom" "^8.5.0"
     "@types/react-dom" "^18.0.0"
 
+"@testing-library/user-event@^14.4.3":
+  version "14.4.3"
+  resolved "https://registry.yarnpkg.com/@testing-library/user-event/-/user-event-14.4.3.tgz#af975e367743fa91989cd666666aec31a8f50591"
+  integrity sha512-kCUc5MEwaEMakkO5x7aoD+DLi02ehmEM2QCGWvNqAS1dV/fAvORWEjnjsEIvml59M7Y5kCkWN6fCCyPOe8OL6Q==
+
 "@timsuchanek/copy@1.4.5":
   version "1.4.5"
   resolved "https://registry.npmjs.org/@timsuchanek/copy/-/copy-1.4.5.tgz#8e9658c056e24e1928a88bed45f9eac6a72b7c40"


### PR DESCRIPTION
…kage; modify global nesting-test

Cypress tests created for TextInput and Textarea components. Jest/Testing-Library tests created for TextInput and TextInputWithButton components.
The general GEL-repo-wide nesting-test.js unit test has had the insertion of a string literal child into the component undergoing testing removed from the test. The test previously tested for the existence of the string literal as a text node which would fail for elements that did not accept children such as button and input.