### PR TITLE
Fixes to Icon, Pictogram and Symbol example pages

### DIFF
--- a/components/icon/examples/50-all-icons.js
+++ b/components/icon/examples/50-all-icons.js
@@ -28,8 +28,6 @@ const Search = (props) => (
 );
 
 function Example({ brand }) {
-	const { COLORS } = useBrand();
-
 	const [inputValue, setInputValue] = useState('');
 	const filteredIcons = inputValue.length
 		? icons.filter((p) =>
@@ -57,7 +55,6 @@ function Example({ brand }) {
 							<Icon />
 							<Name>
 								<code>{`<${icon}\u00A0/>`}</code>
-								<div css={{ color: COLORS.muted }}>“{Icon.defaultProps.assistiveText}”</div>
 							</Name>
 						</Cell>
 					);

--- a/components/pictogram/examples/00-default.js
+++ b/components/pictogram/examples/00-default.js
@@ -7,7 +7,7 @@ import pkg from '../../../GEL.json';
 const { brands } = pkg;
 
 function Example({ brand }) {
-	const { BRAND, COLORS } = useBrand();
+	const { BRAND } = useBrand();
 
 	const informative = Object.keys(components).filter(
 		(component) => !Object.keys(brands).some((code) => component.startsWith(code))
@@ -27,7 +27,6 @@ function Example({ brand }) {
 							<Pictogram />
 							<Name>
 								<code>{`<${pictogram}\u00A0/>`}</code>
-								<div css={{ color: COLORS.muted }}>“{Pictogram.defaultProps.assistiveText}”</div>
 							</Name>
 						</Cell>
 					);
@@ -47,9 +46,6 @@ function Example({ brand }) {
 									<Pictogram />
 									<Name>
 										<code>{`<${pictogram}\u00A0/>`}</code>
-										<div css={{ color: COLORS.muted }}>
-											“{Pictogram.defaultProps.assistiveText}”
-										</div>
 									</Name>
 								</Cell>
 							);

--- a/components/symbol/examples/20-all-symbols.js
+++ b/components/symbol/examples/20-all-symbols.js
@@ -5,8 +5,6 @@ import { Cell, Grid, Name } from './_utils';
 const symbols = Object.keys(components).filter((s) => s.includes('Symbol'));
 
 function Example({ brand }) {
-	const { COLORS } = useBrand();
-
 	return (
 		<GEL brand={brand}>
 			<Grid>
@@ -17,7 +15,6 @@ function Example({ brand }) {
 							<Symbol />
 							<Name>
 								<code>{`<${s}\u00A0/>`}</code>
-								<div css={{ color: COLORS.muted }}>“{Symbol.defaultProps.assistiveText}”</div>
 							</Name>
 						</Cell>
 					);

--- a/components/symbol/examples/30-all-logos.js
+++ b/components/symbol/examples/30-all-logos.js
@@ -25,7 +25,6 @@ function Example({ brand }) {
 							<Symbol align="center" />
 							<Name>
 								<code>{`<${s}\u00A0/>`}</code>
-								<div css={{ color: COLORS.muted }}>“{Symbol.defaultProps.assistiveText}”</div>
 							</Name>
 						</Cell>
 					);
@@ -45,7 +44,6 @@ function Example({ brand }) {
 								<Symbol align={align} css={{ border: `1px dashed ${COLORS.border}` }} />
 								<Name>
 									<code>{`<${component} align="${align}"\u00A0/>`}</code>
-									<div css={{ color: COLORS.muted }}>“{Symbol.defaultProps.assistiveText}”</div>
 								</Name>
 							</Cell>
 						);
@@ -63,7 +61,6 @@ function Example({ brand }) {
 								<Symbol align={align} css={{ border: `1px dashed ${COLORS.border}` }} />
 								<Name>
 									<code>{`<${component} align="${align}"\u00A0/>`}</code>
-									<div css={{ color: COLORS.muted }}>“{Symbol.defaultProps.assistiveText}”</div>
 								</Name>
 							</Cell>
 						);


### PR DESCRIPTION
-fixed issue where defaultProps.assistiveText was causing errors on example pages for icon symbol and pictogram
- was recommended to just remove that entire line as it wasn't really necessary